### PR TITLE
issue #6: added CGREEN_CHILD_EXIT_WITH_FLUSH to control exit behavior…

### DIFF
--- a/src/posix_runner_platform.c
+++ b/src/posix_runner_platform.c
@@ -82,10 +82,13 @@ void run_specified_test_if_child(TestSuite *suite, TestReporter *reporter){
 
 static void stop(void) {
 #ifdef INTERNAL_WITH_GCOV
-    exit(EXIT_SUCCESS);
+    if (1)
 #else
-    _exit(EXIT_SUCCESS);
+    if (NULL != getenv("CGREEN_CHILD_EXIT_WITH_FLUSH"))
 #endif
+        exit(EXIT_SUCCESS);
+    else
+        _exit(EXIT_SUCCESS);
 }
 
 static void ignore_ctrl_c(void) {

--- a/src/win32_runner_platform.c
+++ b/src/win32_runner_platform.c
@@ -19,10 +19,13 @@ static void run_test_in_its_own_process_child(TestSuite *suite, CgreenTest *test
 static void CALLBACK stop(UINT uTimerID, UINT uMsg, DWORD_PTR dwUser, DWORD_PTR dw1, DWORD_PTR dw2)
 {
 #ifdef INTERNAL_WITH_GCOV
-    exit(EXIT_SUCCESS);
+    if (1)
 #else
-    _exit(EXIT_SUCCESS);
+    if (NULL != getenv("CGREEN_CHILD_EXIT_WITH_FLUSH"))
 #endif
+        exit(EXIT_SUCCESS);
+    else
+        _exit(EXIT_SUCCESS);
 }
 
 void die_in(unsigned int seconds) {


### PR DESCRIPTION
… (setting it makes coverage work properly)