### PR TITLE
Double constraints integration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 build
+.idea

--- a/doc/cgreen-guide-en.asciidoc
+++ b/doc/cgreen-guide-en.asciidoc
@@ -595,19 +595,25 @@ Here are the standard constraints...
 | `is_false` | evaluates to false
 | `is_null` | equals null
 | `is_non_null` | is a non null value
+||
 | `is_equal_to(value)` |'== value'
 | `is_not_equal_to(value)` |'!= value'
 | `is_greater_than(value)` |'> value'
 | `is_less_than(value)` |'< value'
+||
 | `is_equal_to_contents_of(pointer, size)` |matches the data pointed to by `pointer` to a size of `size` bytes
 | `is_not_equal_to_contents_of(pointer, size)` |does not match the data pointed to by `pointer` to a size of `size` bytes
+||
 | `is_equal_to_string(value)` |are equal when compared using `strcmp()`
 | `is_not_equal_to_string(value)` |are not equal when compared using `strcmp()`
 | `contains_string(value)` |contains `value` when evaluated using `strstr()`
-| `does_contain_string(value)` |does not contain `value` when evaluated using `strstr()`
+| `does_not_contain_string(value)` |does not contain `value` when evaluated using `strstr()`
 | `begins_with_string(value)` |starts with the string `value`
-| `is_equal_to_double(value)` |are equal to `value` within the number of significant digits (you can set `significant_figures_for_assert_double_are(int figures)`)
+||
+| `is_equal_to_double(value)` |are equal to `value` within the number of significant digits (which you can set with a call to `significant_figures_for_assert_double_are(int figures)`)
 | `is_not_equal_to_double(value)` |are not equal to `value` within the number of significant digits
+| `is_less_than_double(value)` | `< value` withing the number of significant digits
+| `is_greater_than_double(value)` | `> value` within the number of significant digits
 |=========================================================
 
 The boolean assertion macros accept an `int` value. The equality
@@ -869,7 +875,7 @@ tests less clear. And as we add more tests, it might turn out to not
 be common to all tests. This is a typical judgement call that you
 often get to make with `BeforeEach()` and `AfterEach()`.
 
-NOTE: if you use the pure-TDD notation, not having the test subject
+NOTE: If you use the pure-TDD notation, not having the test subject
 named by the `Describe` macro, you can't have the `BeforeEach()` and
 `AfterEach()` either. In this case you can still run a function before
 and after every test. Just nominate any `void(void)` function by
@@ -1079,7 +1085,7 @@ suites, you can use `create_named_test_suite()` instead of
 constant into `create_named_test_suite()`.
 
 What happens to `setup` and `teardown` functions in a `TestSuite` that
-contains other `TestSuite`s?
+contains other `TestSuite`:s?
 
 Well firstly, *Cgreen* does not `fork()` when running a suite.  It
 leaves it up to the child suite to `fork()` the individual tests.
@@ -1381,7 +1387,7 @@ The ideal is to have minimal stubs written for each individual test.
 The problem with streams
 ~~~~~~~~~~~~~~~~~~~~~~~~
             
-How would we test this code...?
+How would we test the following code...?
 
 [source,c]
 -----------------------
@@ -1710,10 +1716,16 @@ same as for the assertions we saw earlier):
 |`contains_string(value)`                                 |String
 |`does_not_contain_string(value)`                         |String
 |`begins_with_string(value)`                              |String
-|                                                         |
+||
 |`is_equal_to_double(value)`                              |Double
 |`is_not_equal_to_double(value)`                          |Double
+|`is_less_than_double(value)`                             |Double
+|`is_greater_than_double(value)`                          |Double
 |==========================================================================
+
+For the double valued constraints you can set the number of
+significant digits to consider a match with a call to
+`significant_figures_for_assert_double_are(int figures)`.
 
 Then there are two ways to return results:
 

--- a/include/cgreen/constraint.h
+++ b/include/cgreen/constraint.h
@@ -69,6 +69,8 @@ Constraint *create_begins_with_string_constraint(const char* expected_value, con
 
 Constraint *create_equal_to_double_constraint(double expected_value, const char *expected_value_name);
 Constraint *create_not_equal_to_double_constraint(double expected_value, const char *expected_value_name);
+Constraint *create_less_than_double_constraint(double expected_value, const char *expected_value_name);
+Constraint *create_greater_than_double_constraint(double expected_value, const char *expected_value_name);
 Constraint *create_return_value_constraint(intptr_t value_to_return);
 Constraint *create_set_parameter_value_constraint(const char *parameter_name, intptr_t value_to_set, size_t size_to_set);
 
@@ -85,6 +87,12 @@ bool is_parameter(const Constraint *);
 bool constraint_is_not_for_parameter(const Constraint *, const char *);
 bool constraint_is_for_parameter(const Constraint *, const char *);
 bool constraint_is_for_parameter_in(const Constraint *, const char *);
+bool doubles_are_equal(double tried, double expected);
+bool double_is_lesser(double actual, double expected);
+bool double_is_greater(double actual, double expected);
+
+int get_significant_figures();
+void significant_figures_for_assert_double_are(int figures);
 
 #ifdef __cplusplus
     }

--- a/include/cgreen/constraint_syntax_helpers.h
+++ b/include/cgreen/constraint_syntax_helpers.h
@@ -35,6 +35,10 @@ extern "C" {
 #define is_equal_to_double(value) create_equal_to_double_constraint(value, #value)
 #define is_not_equal_to_double(value) create_not_equal_to_double_constraint(value, #value)
 
+#define is_less_than_double(value) create_less_than_double_constraint(value, #value)
+#define is_greater_than_double(value) create_greater_than_double_constraint(value, #value)
+
+
 #define will_return(value) create_return_value_constraint((intptr_t)value)
 #define will_set_contents_of_parameter(parameter_name, value, size) create_set_parameter_value_constraint(#parameter_name, (intptr_t)value, (size_t)size)
 

--- a/include/cgreen/cpp_constraint.h
+++ b/include/cgreen/cpp_constraint.h
@@ -35,6 +35,12 @@ bool compare_do_not_want_value(CppConstraint<T> *constraint, T actual) {
 
 template<typename T>
 void test_want_value(CppConstraint<T> *constraint, const char *function, T actual, const char *test_file, int test_line, TestReporter *reporter) {
+    (void)constraint;
+    (void)function;
+    (void)actual;
+    (void)test_file;
+    (void)test_line;
+    (void)reporter;
 }
 
 #include <stdlib.h>

--- a/include/cgreen/internal/assertions_internal.h
+++ b/include/cgreen/internal/assertions_internal.h
@@ -45,6 +45,8 @@ void assert_that_double_(const char *file, int line, const char *actual_string, 
 
 const char *show_null_as_the_string_null(const char *string);
 bool doubles_are_equal(double tried, double expected);
+bool double_is_lesser(double actual, double expected);
+bool double_is_greater(double actual, double expected);
 
 #ifdef __cplusplus
     }

--- a/src/assertions.c
+++ b/src/assertions.c
@@ -9,26 +9,12 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <float.h>
 
 #ifdef __cplusplus
 namespace cgreen {
 #endif
 
-
-#ifdef max
-#undef max
-#endif
-
-#ifdef min
-#undef min
-#endif
-
-#define max(a,b) ((a) > (b) ? (a) : (b))
-#define min(a,b) ((a) > (b) ? (b) : (a))
-
-static double accuracy(int significant_figures, double largest);
-
-static int significant_figures = 8;
 
 void assert_that_(const char *file, int line, const char *actual_string, intptr_t actual, Constraint* constraint) {
 
@@ -97,11 +83,11 @@ void assert_that_double_(const char *file, int line, const char *expression, dou
     (*get_test_reporter()->assert_true)(get_test_reporter(), file, line, (*constraint->compare)(constraint, (intptr_t)boxed_actual),
             "Expected [%s] to [%s] [%s] within [%d] significant figures\n"
             "\t\tactual value:\t%08f\n"
-            "\t\texpected value:\t%08f",
+            "\t\texpected value:\t%08f\n",
             expression,
             constraint->name,
             constraint->expected_value_name,
-            significant_figures,
+            get_significant_figures(),
             actual,
             as_double(constraint->expected_value));
 
@@ -133,7 +119,7 @@ void assert_double_equal_(const char *file, int line, const char *expression, do
             file,
             line,
             doubles_are_equal(tried, expected),
-            "[%s] should be [%f] within %d significant figures but was [%f]\n", expression, expected, significant_figures, tried);
+            "[%s] should be [%f] within %d significant figures but was [%f]\n", expression, expected, get_significant_figures(), tried);
 }
 
 void assert_double_not_equal_(const char *file, int line, const char *expression, double tried, double expected) {
@@ -142,7 +128,7 @@ void assert_double_not_equal_(const char *file, int line, const char *expression
             file,
             line,
             ! doubles_are_equal(tried, expected),
-            "[%s] should not be [%f] within %d significant figures but was [%f]\n", expression, expected, significant_figures, tried);
+            "[%s] should not be [%f] within %d significant figures but was [%f]\n", expression, expected, get_significant_figures(), tried);
 }
 
 void assert_string_equal_(const char *file, int line, const char *expression, const char *tried, const char *expected) {
@@ -163,21 +149,10 @@ void assert_string_not_equal_(const char *file, int line, const char *expression
             "[%s] should not be [%s] but was\n", expression, show_null_as_the_string_null(expected));
 }
 
-void significant_figures_for_assert_double_are(int figures) {
-    significant_figures = figures;
-}
-
 const char *show_null_as_the_string_null(const char *string) {
     return (string == NULL ? "NULL" : string);
 }
 
-bool doubles_are_equal(double tried, double expected) {
-    return max(tried, expected) - min(tried, expected) < accuracy(significant_figures, max(tried, expected));
-}
-
-static double accuracy(int figures, double largest) {
-    return pow(10, 1 + (int)log10(largest) - figures);
-}
 
 #ifdef __cplusplus
 } // namespace cgreen

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -126,7 +126,7 @@ macro_add_test(
             # ... but execute the following SED commands on the output before making the comparison
             s%${CMAKE_CURRENT_SOURCE_DIR}/%%g
             s%\".*constraint_messages\"%\"constraint_messages\"%g
-            s/:[0-9]*:/:/g
+            s/:[0-9]\\\\+:/:/g
 )
 
 macro_add_test(
@@ -143,7 +143,7 @@ macro_add_test(
             # ... but execute the following SED commands on the output before making the comparison
             s%${CMAKE_CURRENT_SOURCE_DIR}/%%g                   # remove source path
             s%\".*mock_messages\"%\"mock_messages\"%g           # remove any leading 'lib' prefix
-            s/:[0-9]*:/:/g                                      # remove line numbers in messages
+            s/:[0-9]\\\\+:/:/g                                  # remove line numbers in messages
 )
 
 # add verification that all public api is available as it should

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -125,7 +125,8 @@ macro_add_test(
             ${CMAKE_CURRENT_SOURCE_DIR}/${constraint_messages_library}.expected.${LANG}
             # ... but execute the following SED commands on the output before making the comparison
             s%${CMAKE_CURRENT_SOURCE_DIR}/%%g
-            s%\".*constraint_messages\"%\"constraint_messages\"%g # should like to have $<TARGET_FILE_NAME:${constraint_messages_library}>
+            s%\".*constraint_messages\"%\"constraint_messages\"%g
+            s/:[0-9]*:/:/g
 )
 
 macro_add_test(
@@ -140,8 +141,9 @@ macro_add_test(
             # ... then compare it to
             ${CMAKE_CURRENT_SOURCE_DIR}/${mock_messages_library}.expected.${LANG}
             # ... but execute the following SED commands on the output before making the comparison
-            s%${CMAKE_CURRENT_SOURCE_DIR}/%%g
-            s%\".*mock_messages\"%\"mock_messages\"%g # should like to have $<TARGET_FILE_NAME:${mock_messages_library}>
+            s%${CMAKE_CURRENT_SOURCE_DIR}/%%g                   # remove source path
+            s%\".*mock_messages\"%\"mock_messages\"%g           # remove any leading 'lib' prefix
+            s/:[0-9]*:/:/g                                      # remove line numbers in messages
 )
 
 # add verification that all public api is available as it should

--- a/tests/assertion_tests.c
+++ b/tests/assertion_tests.c
@@ -176,11 +176,36 @@ Ensure(double_differences_do_not_matter_past_significant_figures) {
     assert_that_double(1.113, is_equal_to_double(1.115));
     assert_that_double(1113, is_equal_to_double(1115));
     assert_that_double(1113000, is_equal_to_double(1115000));
+    assert_that_double(1.1199999999, is_less_than_double(1.11));
+    assert_that_double(1.11, is_greater_than_double(1.119999));
+}
+
+Ensure(can_check_equality_of_negative_floating_point_numbers) {
+    significant_figures_for_assert_double_are(3);
+    assert_that_double(-1.113, is_equal_to_double(-1.115));
+    assert_that_double(-1.13, is_not_equal_to_double(-1.15));
+}
+
+Ensure(double_one_is_less_than_two) {
+    assert_that_double(1.0, is_less_than_double(2.0));
+}
+
+Ensure(double_one_is_greater_than_zero) {
+    assert_that_double(1.0, is_greater_than_double(0.0));
+}
+
+Ensure(double_can_compare_negative_numbers) {
+    assert_that_double(1.0, is_greater_than_double(-10.0));
+    assert_that_double(-2.0, is_less_than_double(1.0));
+    assert_that_double(-21.0, is_less_than_double(-10.0));
+    assert_that_double(-11.0, is_greater_than_double(-12.0));
 }
 
 Ensure(double_differences_matter_past_significant_figures) {
     significant_figures_for_assert_double_are(4);
     assert_that_double(1.113, is_not_equal_to_double(1.115));
+    assert_that_double(1.113, is_less_than_double(1.115));
+    assert_that_double(1.115, is_greater_than_double(1.113));
     assert_that_double(1113, is_not_equal_to_double(1115));
     assert_that_double(1113000, is_not_equal_to_double(1115000));
 }
@@ -188,7 +213,7 @@ Ensure(double_differences_matter_past_significant_figures) {
 Ensure(double_assertions_can_have_custom_messages) {
     significant_figures_for_assert_double_are(3);
 
-    /* this passes because the difference is below the set signifigant figure */
+    /* this passes because the difference is below the set significant figure */
     assert_that_double(1.113, is_equal_to_double(1.115));
 }
 
@@ -283,6 +308,10 @@ TestSuite *assertion_tests() {
     add_test(suite, one_should_assert_long_double_equal_to_one);
     add_test(suite, zero_should_assert_long_double_not_equal_to_one);
     add_test(suite, double_differences_do_not_matter_past_significant_figures);
+    add_test(suite, can_check_equality_of_negative_floating_point_numbers);
+    add_test(suite, double_one_is_less_than_two);
+    add_test(suite, double_one_is_greater_than_zero);
+    add_test(suite, double_can_compare_negative_numbers);
     add_test(suite, double_differences_matter_past_significant_figures);
     add_test(suite, double_assertions_can_have_custom_messages);
     add_test(suite, identical_string_copies_should_match);

--- a/tests/constraint_messages.expected.c
+++ b/tests/constraint_messages.expected.c
@@ -1,98 +1,98 @@
 Running "constraint_messages" (24 tests)...
-constraint_messages_tests.c:117: Failure: FailureMessage -> for_always_followed_by_expectation 
+constraint_messages_tests.c: Failure: FailureMessage -> for_always_followed_by_expectation 
 	Mocked function [some_mock] already has an expectation that it will always be called a certain way; any expectations declared after an always expectation are invalid
 
-constraint_messages_tests.c:92: Failure: FailureMessage -> for_assert_that 
+constraint_messages_tests.c: Failure: FailureMessage -> for_assert_that 
 	Expected [0 == 1] to [be true]
 
-constraint_messages_tests.c:80: Failure: FailureMessage -> for_begins_with_string 
+constraint_messages_tests.c: Failure: FailureMessage -> for_begins_with_string 
 	Expected [does_not_begin_with_fourty_five] to [begin with string] [fourty_five]
 		actual value:			["this string does not begin with fortyfive"]
 		expected to begin with:		["fourtyfive"]
 
-constraint_messages_tests.c:70: Failure: FailureMessage -> for_contains_string 
+constraint_messages_tests.c: Failure: FailureMessage -> for_contains_string 
 	Expected [not_containing_fourty_five] to [contain string] [fourty_five]
 		actual value:			["this text is thirtythree"]
 		expected to contain:		["fortyfive"]
 
-constraint_messages_tests.c:75: Failure: FailureMessage -> for_does_not_contain_string 
+constraint_messages_tests.c: Failure: FailureMessage -> for_does_not_contain_string 
 	Expected [contains_fourty_five] to [not contain string] [fourty_five]
 		actual value:			["this string is fourtyfive"]
 		expected to not contain:	["fourtyfive"]
 
-constraint_messages_tests.c:84: Failure: FailureMessage -> for_equal_to_double 
+constraint_messages_tests.c: Failure: FailureMessage -> for_equal_to_double 
 	Expected [0] to [equal double] [1] within [8] significant figures
 		actual value:	0.000000
 		expected value:	1.000000
 
-constraint_messages_tests.c:30: Failure: FailureMessage -> for_is_equal_to 
+constraint_messages_tests.c: Failure: FailureMessage -> for_is_equal_to 
 	Expected [fourty_five] to [equal] [thirty_three]
 		actual value:			[45]
 		expected value:			[33]
 
-constraint_messages_tests.c:50: Failure: FailureMessage -> for_is_equal_to_contents_of 
+constraint_messages_tests.c: Failure: FailureMessage -> for_is_equal_to_contents_of 
 	Expected [thirty_three] to [equal contents of] [fourty_five]
 		at offset:			[9]
 
-constraint_messages_tests.c:60: Failure: FailureMessage -> for_is_equal_to_string 
+constraint_messages_tests.c: Failure: FailureMessage -> for_is_equal_to_string 
 	Expected [thirty_three] to [equal string] [fourty_five]
 		actual value:			["this string is thirtythree"]
 		expected to equal:		["this string is fortyfive"]
 
-constraint_messages_tests.c:40: Failure: FailureMessage -> for_is_greater_than 
+constraint_messages_tests.c: Failure: FailureMessage -> for_is_greater_than 
 	Expected [thirty_three] to [be greater than] [fourty_five]
 		actual value:			[33]
 		expected to be greater than:	[45]
 
-constraint_messages_tests.c:45: Failure: FailureMessage -> for_is_less_than 
+constraint_messages_tests.c: Failure: FailureMessage -> for_is_less_than 
 	Expected [fourty_five] to [be less than] [thirty_three]
 		actual value:			[45]
 		expected to be less than:	[33]
 
-constraint_messages_tests.c:25: Failure: FailureMessage -> for_is_non_null 
+constraint_messages_tests.c: Failure: FailureMessage -> for_is_non_null 
 	Expected [pointer] to [be non null]
 
-constraint_messages_tests.c:35: Failure: FailureMessage -> for_is_not_equal_to 
+constraint_messages_tests.c: Failure: FailureMessage -> for_is_not_equal_to 
 	Expected [should_not_be_fourty_five] to [not equal] [forty_five]
 		actual value:			[45]
 
-constraint_messages_tests.c:55: Failure: FailureMessage -> for_is_not_equal_to_contents_of 
+constraint_messages_tests.c: Failure: FailureMessage -> for_is_not_equal_to_contents_of 
 	Expected [fourty_five_and_up] to [not equal contents of] [another_fourty_five_and_up]
 		at offset:			[-1]
 
-constraint_messages_tests.c:65: Failure: FailureMessage -> for_is_not_equal_to_string 
+constraint_messages_tests.c: Failure: FailureMessage -> for_is_not_equal_to_string 
 	Expected [another_fourty_five] to [not equal string] [fourty_five]
 		actual value:			["this string is fourtyfive"]
 
-constraint_messages_tests.c:20: Failure: FailureMessage -> for_is_null 
+constraint_messages_tests.c: Failure: FailureMessage -> for_is_null 
 	Expected [pointer] to [be null]
 
-constraint_messages_tests.c:96: Failure: FailureMessage -> for_mock_called_more_times_than_expected 
+constraint_messages_tests.c: Failure: FailureMessage -> for_mock_called_more_times_than_expected 
 	Mocked function [some_mock] was called too many times
 
-constraint_messages_tests.c:110: Failure: FailureMessage -> for_mock_called_with_unexpected_parameter_value 
+constraint_messages_tests.c: Failure: FailureMessage -> for_mock_called_with_unexpected_parameter_value 
 	Expected [[parameter] parameter in [some_mock]] to [equal] [1]
 		actual value:			[0]
 		expected value:			[1]
 
-constraint_messages_tests.c:96: Failure: FailureMessage -> for_mock_called_without_expectation 
+constraint_messages_tests.c: Failure: FailureMessage -> for_mock_called_without_expectation 
 	Mocked function [some_mock] did not have an expectation that it would be called
 
-constraint_messages_tests.c:126: Failure: FailureMessage -> for_mock_parameter_name_not_matching_constraint_parameter_name 
+constraint_messages_tests.c: Failure: FailureMessage -> for_mock_parameter_name_not_matching_constraint_parameter_name 
 	Mocked function [some_mock] did not define a parameter named [PARAMETER]. Did you misspell it in the expectation or forget it in the mock's argument list?
 
-constraint_messages_tests.c:136: Failure: FailureMessage -> for_no_mock_parameters_with_parameter_constraint 
+constraint_messages_tests.c: Failure: FailureMessage -> for_no_mock_parameters_with_parameter_constraint 
 	Mocked function [forgot_to_pass_parameters_mock] did not define a parameter named [x]. Did you misspell it in the expectation or forget it in the mock's argument list?
 
-constraint_messages_tests.c:88: Failure: FailureMessage -> for_not_equal_to_double 
+constraint_messages_tests.c: Failure: FailureMessage -> for_not_equal_to_double 
 	Expected [0] to [not equal double] [0] within [8] significant figures
 		actual value:	0.000000
 		expected value:	0.000000
 
-constraint_messages_tests.c:121: Failure: FailureMessage -> for_violated_never_expect 
+constraint_messages_tests.c: Failure: FailureMessage -> for_violated_never_expect 
 	Mocked function [some_mock] has an expectation that it will never be called, but it was
 
-constraint_messages_tests.c:140: Exception: FailureMessage -> increments_exception_count_when_terminating_via_SIGQUIT 
+constraint_messages_tests.c: Exception: FailureMessage -> increments_exception_count_when_terminating_via_SIGQUIT 
 	Test terminated with signal: Terminated
 
 Completed "FailureMessage": 0 passes, 23 failures, 1 exception.

--- a/tests/constraint_messages.expected.c
+++ b/tests/constraint_messages.expected.c
@@ -1,4 +1,4 @@
-Running "constraint_messages" (24 tests)...
+Running "constraint_messages" (32 tests)...
 constraint_messages_tests.c: Failure: FailureMessage -> for_always_followed_by_expectation 
 	Mocked function [some_mock] already has an expectation that it will always be called a certain way; any expectations declared after an always expectation are invalid
 
@@ -25,6 +25,13 @@ constraint_messages_tests.c: Failure: FailureMessage -> for_equal_to_double
 		actual value:	0.000000
 		expected value:	1.000000
 
+
+constraint_messages_tests.c: Failure: FailureMessage -> for_equal_to_double_negative 
+	Expected [-1] to [equal double] [-2] within [8] significant figures
+		actual value:	-1.000000
+		expected value:	-2.000000
+
+
 constraint_messages_tests.c: Failure: FailureMessage -> for_is_equal_to 
 	Expected [fourty_five] to [equal] [thirty_three]
 		actual value:			[45]
@@ -33,6 +40,12 @@ constraint_messages_tests.c: Failure: FailureMessage -> for_is_equal_to
 constraint_messages_tests.c: Failure: FailureMessage -> for_is_equal_to_contents_of 
 	Expected [thirty_three] to [equal contents of] [fourty_five]
 		at offset:			[9]
+
+constraint_messages_tests.c: Failure: FailureMessage -> for_is_equal_to_double 
+	Expected [four_point_five] to [equal double] [three_point_three] within [8] significant figures
+		actual value:	4.500000
+		expected value:	3.300000
+
 
 constraint_messages_tests.c: Failure: FailureMessage -> for_is_equal_to_string 
 	Expected [thirty_three] to [equal string] [fourty_five]
@@ -44,10 +57,34 @@ constraint_messages_tests.c: Failure: FailureMessage -> for_is_greater_than
 		actual value:			[33]
 		expected to be greater than:	[45]
 
+constraint_messages_tests.c: Failure: FailureMessage -> for_is_greater_than_double 
+	Expected [three_point_three] to [be greater than double] [four_point_five] within [8] significant figures
+		actual value:	3.300000
+		expected value:	4.500000
+
+
+constraint_messages_tests.c: Failure: FailureMessage -> for_is_greater_than_double_with_accuracy 
+	Expected [1.0] to [be greater than double] [1.0 + 1.0e-3 + DBL_EPSILON] within [4] significant figures
+		actual value:	1.000000
+		expected value:	1.001000
+
+
 constraint_messages_tests.c: Failure: FailureMessage -> for_is_less_than 
 	Expected [fourty_five] to [be less than] [thirty_three]
 		actual value:			[45]
 		expected to be less than:	[33]
+
+constraint_messages_tests.c: Failure: FailureMessage -> for_is_less_than_double 
+	Expected [four_point_five] to [be less than double] [three_point_three] within [8] significant figures
+		actual value:	4.500000
+		expected value:	3.300000
+
+
+constraint_messages_tests.c: Failure: FailureMessage -> for_is_less_than_double_with_accuracy 
+	Expected [1.0] to [be less than double] [1.0 - 1.0e-3 - DBL_EPSILON] within [4] significant figures
+		actual value:	1.000000
+		expected value:	0.999000
+
 
 constraint_messages_tests.c: Failure: FailureMessage -> for_is_non_null 
 	Expected [pointer] to [be non null]
@@ -59,6 +96,12 @@ constraint_messages_tests.c: Failure: FailureMessage -> for_is_not_equal_to
 constraint_messages_tests.c: Failure: FailureMessage -> for_is_not_equal_to_contents_of 
 	Expected [fourty_five_and_up] to [not equal contents of] [another_fourty_five_and_up]
 		at offset:			[-1]
+
+constraint_messages_tests.c: Failure: FailureMessage -> for_is_not_equal_to_double 
+	Expected [four_point_five] to [not equal double] [almost_four_point_five] within [4] significant figures
+		actual value:	4.500000
+		expected value:	4.499900
+
 
 constraint_messages_tests.c: Failure: FailureMessage -> for_is_not_equal_to_string 
 	Expected [another_fourty_five] to [not equal string] [fourty_five]
@@ -89,11 +132,18 @@ constraint_messages_tests.c: Failure: FailureMessage -> for_not_equal_to_double
 		actual value:	0.000000
 		expected value:	0.000000
 
+
+constraint_messages_tests.c: Failure: FailureMessage -> for_not_equal_to_double_negative 
+	Expected [-1] to [not equal double] [-1] within [8] significant figures
+		actual value:	-1.000000
+		expected value:	-1.000000
+
+
 constraint_messages_tests.c: Failure: FailureMessage -> for_violated_never_expect 
 	Mocked function [some_mock] has an expectation that it will never be called, but it was
 
 constraint_messages_tests.c: Exception: FailureMessage -> increments_exception_count_when_terminating_via_SIGQUIT 
 	Test terminated with signal: Terminated
 
-Completed "FailureMessage": 0 passes, 23 failures, 1 exception.
-Completed "constraint_messages": 0 passes, 23 failures, 1 exception.
+Completed "FailureMessage": 0 passes, 31 failures, 1 exception.
+Completed "constraint_messages": 0 passes, 31 failures, 1 exception.

--- a/tests/constraint_messages.expected.c++
+++ b/tests/constraint_messages.expected.c++
@@ -1,4 +1,4 @@
-Running "constraint_messages" (27 tests)...
+Running "constraint_messages" (35 tests)...
 constraint_messages_tests.c: Failure: FailureMessage -> for_always_followed_by_expectation 
 	Mocked function [some_mock] already has an expectation that it will always be called a certain way; any expectations declared after an always expectation are invalid
 
@@ -25,6 +25,13 @@ constraint_messages_tests.c: Failure: FailureMessage -> for_equal_to_double
 		actual value:	0.000000
 		expected value:	1.000000
 
+
+constraint_messages_tests.c: Failure: FailureMessage -> for_equal_to_double_negative 
+	Expected [-1] to [equal double] [-2] within [8] significant figures
+		actual value:	-1.000000
+		expected value:	-2.000000
+
+
 constraint_messages_tests.c: Exception: FailureMessage -> for_incorrect_assert_throws 
 	an exception was thrown during test: [something else]
 
@@ -37,6 +44,12 @@ constraint_messages_tests.c: Failure: FailureMessage -> for_is_equal_to_contents
 	Expected [thirty_three] to [equal contents of] [fourty_five]
 		at offset:			[9]
 
+constraint_messages_tests.c: Failure: FailureMessage -> for_is_equal_to_double 
+	Expected [four_point_five] to [equal double] [three_point_three] within [8] significant figures
+		actual value:	4.500000
+		expected value:	3.300000
+
+
 constraint_messages_tests.c: Failure: FailureMessage -> for_is_equal_to_string 
 	Expected [thirty_three] to [equal string] [fourty_five]
 		actual value:			["this string is thirtythree"]
@@ -47,10 +60,34 @@ constraint_messages_tests.c: Failure: FailureMessage -> for_is_greater_than
 		actual value:			[33]
 		expected to be greater than:	[45]
 
+constraint_messages_tests.c: Failure: FailureMessage -> for_is_greater_than_double 
+	Expected [three_point_three] to [be greater than double] [four_point_five] within [8] significant figures
+		actual value:	3.300000
+		expected value:	4.500000
+
+
+constraint_messages_tests.c: Failure: FailureMessage -> for_is_greater_than_double_with_accuracy 
+	Expected [1.0] to [be greater than double] [1.0 + 1.0e-3 + DBL_EPSILON] within [4] significant figures
+		actual value:	1.000000
+		expected value:	1.001000
+
+
 constraint_messages_tests.c: Failure: FailureMessage -> for_is_less_than 
 	Expected [fourty_five] to [be less than] [thirty_three]
 		actual value:			[45]
 		expected to be less than:	[33]
+
+constraint_messages_tests.c: Failure: FailureMessage -> for_is_less_than_double 
+	Expected [four_point_five] to [be less than double] [three_point_three] within [8] significant figures
+		actual value:	4.500000
+		expected value:	3.300000
+
+
+constraint_messages_tests.c: Failure: FailureMessage -> for_is_less_than_double_with_accuracy 
+	Expected [1.0] to [be less than double] [1.0 - 1.0e-3 - DBL_EPSILON] within [4] significant figures
+		actual value:	1.000000
+		expected value:	0.999000
+
 
 constraint_messages_tests.c: Failure: FailureMessage -> for_is_non_null 
 	Expected [pointer] to [be non null]
@@ -62,6 +99,12 @@ constraint_messages_tests.c: Failure: FailureMessage -> for_is_not_equal_to
 constraint_messages_tests.c: Failure: FailureMessage -> for_is_not_equal_to_contents_of 
 	Expected [fourty_five_and_up] to [not equal contents of] [another_fourty_five_and_up]
 		at offset:			[-1]
+
+constraint_messages_tests.c: Failure: FailureMessage -> for_is_not_equal_to_double 
+	Expected [four_point_five] to [not equal double] [almost_four_point_five] within [4] significant figures
+		actual value:	4.500000
+		expected value:	4.499900
+
 
 constraint_messages_tests.c: Failure: FailureMessage -> for_is_not_equal_to_string 
 	Expected [another_fourty_five] to [not equal string] [fourty_five]
@@ -92,11 +135,18 @@ constraint_messages_tests.c: Failure: FailureMessage -> for_not_equal_to_double
 		actual value:	0.000000
 		expected value:	0.000000
 
+
+constraint_messages_tests.c: Failure: FailureMessage -> for_not_equal_to_double_negative 
+	Expected [-1] to [not equal double] [-1] within [8] significant figures
+		actual value:	-1.000000
+		expected value:	-1.000000
+
+
 constraint_messages_tests.c: Failure: FailureMessage -> for_violated_never_expect 
 	Mocked function [some_mock] has an expectation that it will never be called, but it was
 
 constraint_messages_tests.c: Failure: FailureMessage -> if_exception_was_expected_but_nothing_thrown 
-	Expected [(void)5] to throw [stdstring]
+	Expected [(void)5] to throw [std::string]
 
 constraint_messages_tests.c: Exception: FailureMessage -> increments_exception_count_when_terminating_via_SIGQUIT 
 	Test terminated with signal: Terminated
@@ -104,5 +154,5 @@ constraint_messages_tests.c: Exception: FailureMessage -> increments_exception_c
 constraint_messages_tests.c: Exception: FailureMessage -> increments_exception_count_when_throwing 
 	Test terminated unexpectedly, likely from a non-standard exception or Posix signal
 
-Completed "FailureMessage": 0 passes, 24 failures, 3 exceptions.
-Completed "constraint_messages": 0 passes, 24 failures, 3 exceptions.
+Completed "FailureMessage": 0 passes, 32 failures, 3 exceptions.
+Completed "constraint_messages": 0 passes, 32 failures, 3 exceptions.

--- a/tests/constraint_messages.expected.c++
+++ b/tests/constraint_messages.expected.c++
@@ -1,107 +1,107 @@
 Running "constraint_messages" (27 tests)...
-constraint_messages_tests.c:117: Failure: FailureMessage -> for_always_followed_by_expectation 
+constraint_messages_tests.c: Failure: FailureMessage -> for_always_followed_by_expectation 
 	Mocked function [some_mock] already has an expectation that it will always be called a certain way; any expectations declared after an always expectation are invalid
 
-constraint_messages_tests.c:92: Failure: FailureMessage -> for_assert_that 
+constraint_messages_tests.c: Failure: FailureMessage -> for_assert_that 
 	Expected [0 == 1] to [be true]
 
-constraint_messages_tests.c:80: Failure: FailureMessage -> for_begins_with_string 
+constraint_messages_tests.c: Failure: FailureMessage -> for_begins_with_string 
 	Expected [does_not_begin_with_fourty_five] to [begin with string] [fourty_five]
 		actual value:			["this string does not begin with fortyfive"]
 		expected to begin with:		["fourtyfive"]
 
-constraint_messages_tests.c:70: Failure: FailureMessage -> for_contains_string 
+constraint_messages_tests.c: Failure: FailureMessage -> for_contains_string 
 	Expected [not_containing_fourty_five] to [contain string] [fourty_five]
 		actual value:			["this text is thirtythree"]
 		expected to contain:		["fortyfive"]
 
-constraint_messages_tests.c:75: Failure: FailureMessage -> for_does_not_contain_string 
+constraint_messages_tests.c: Failure: FailureMessage -> for_does_not_contain_string 
 	Expected [contains_fourty_five] to [not contain string] [fourty_five]
 		actual value:			["this string is fourtyfive"]
 		expected to not contain:	["fourtyfive"]
 
-constraint_messages_tests.c:84: Failure: FailureMessage -> for_equal_to_double 
+constraint_messages_tests.c: Failure: FailureMessage -> for_equal_to_double 
 	Expected [0] to [equal double] [1] within [8] significant figures
 		actual value:	0.000000
 		expected value:	1.000000
 
-constraint_messages_tests.c:145: Exception: FailureMessage -> for_incorrect_assert_throws 
+constraint_messages_tests.c: Exception: FailureMessage -> for_incorrect_assert_throws 
 	an exception was thrown during test: [something else]
 
-constraint_messages_tests.c:30: Failure: FailureMessage -> for_is_equal_to 
+constraint_messages_tests.c: Failure: FailureMessage -> for_is_equal_to 
 	Expected [fourty_five] to [equal] [thirty_three]
 		actual value:			[45]
 		expected value:			[33]
 
-constraint_messages_tests.c:50: Failure: FailureMessage -> for_is_equal_to_contents_of 
+constraint_messages_tests.c: Failure: FailureMessage -> for_is_equal_to_contents_of 
 	Expected [thirty_three] to [equal contents of] [fourty_five]
 		at offset:			[9]
 
-constraint_messages_tests.c:60: Failure: FailureMessage -> for_is_equal_to_string 
+constraint_messages_tests.c: Failure: FailureMessage -> for_is_equal_to_string 
 	Expected [thirty_three] to [equal string] [fourty_five]
 		actual value:			["this string is thirtythree"]
 		expected to equal:		["this string is fortyfive"]
 
-constraint_messages_tests.c:40: Failure: FailureMessage -> for_is_greater_than 
+constraint_messages_tests.c: Failure: FailureMessage -> for_is_greater_than 
 	Expected [thirty_three] to [be greater than] [fourty_five]
 		actual value:			[33]
 		expected to be greater than:	[45]
 
-constraint_messages_tests.c:45: Failure: FailureMessage -> for_is_less_than 
+constraint_messages_tests.c: Failure: FailureMessage -> for_is_less_than 
 	Expected [fourty_five] to [be less than] [thirty_three]
 		actual value:			[45]
 		expected to be less than:	[33]
 
-constraint_messages_tests.c:25: Failure: FailureMessage -> for_is_non_null 
+constraint_messages_tests.c: Failure: FailureMessage -> for_is_non_null 
 	Expected [pointer] to [be non null]
 
-constraint_messages_tests.c:35: Failure: FailureMessage -> for_is_not_equal_to 
+constraint_messages_tests.c: Failure: FailureMessage -> for_is_not_equal_to 
 	Expected [should_not_be_fourty_five] to [not equal] [forty_five]
 		actual value:			[45]
 
-constraint_messages_tests.c:55: Failure: FailureMessage -> for_is_not_equal_to_contents_of 
+constraint_messages_tests.c: Failure: FailureMessage -> for_is_not_equal_to_contents_of 
 	Expected [fourty_five_and_up] to [not equal contents of] [another_fourty_five_and_up]
 		at offset:			[-1]
 
-constraint_messages_tests.c:65: Failure: FailureMessage -> for_is_not_equal_to_string 
+constraint_messages_tests.c: Failure: FailureMessage -> for_is_not_equal_to_string 
 	Expected [another_fourty_five] to [not equal string] [fourty_five]
 		actual value:			["this string is fourtyfive"]
 
-constraint_messages_tests.c:20: Failure: FailureMessage -> for_is_null 
+constraint_messages_tests.c: Failure: FailureMessage -> for_is_null 
 	Expected [pointer] to [be null]
 
-constraint_messages_tests.c:96: Failure: FailureMessage -> for_mock_called_more_times_than_expected 
+constraint_messages_tests.c: Failure: FailureMessage -> for_mock_called_more_times_than_expected 
 	Mocked function [some_mock] was called too many times
 
-constraint_messages_tests.c:110: Failure: FailureMessage -> for_mock_called_with_unexpected_parameter_value 
+constraint_messages_tests.c: Failure: FailureMessage -> for_mock_called_with_unexpected_parameter_value 
 	Expected [[parameter] parameter in [some_mock]] to [equal] [1]
 		actual value:			[0]
 		expected value:			[1]
 
-constraint_messages_tests.c:96: Failure: FailureMessage -> for_mock_called_without_expectation 
+constraint_messages_tests.c: Failure: FailureMessage -> for_mock_called_without_expectation 
 	Mocked function [some_mock] did not have an expectation that it would be called
 
-constraint_messages_tests.c:126: Failure: FailureMessage -> for_mock_parameter_name_not_matching_constraint_parameter_name 
+constraint_messages_tests.c: Failure: FailureMessage -> for_mock_parameter_name_not_matching_constraint_parameter_name 
 	Mocked function [some_mock] did not define a parameter named [PARAMETER]. Did you misspell it in the expectation or forget it in the mock's argument list?
 
-constraint_messages_tests.c:136: Failure: FailureMessage -> for_no_mock_parameters_with_parameter_constraint 
+constraint_messages_tests.c: Failure: FailureMessage -> for_no_mock_parameters_with_parameter_constraint 
 	Mocked function [forgot_to_pass_parameters_mock] did not define a parameter named [x]. Did you misspell it in the expectation or forget it in the mock's argument list?
 
-constraint_messages_tests.c:88: Failure: FailureMessage -> for_not_equal_to_double 
+constraint_messages_tests.c: Failure: FailureMessage -> for_not_equal_to_double 
 	Expected [0] to [not equal double] [0] within [8] significant figures
 		actual value:	0.000000
 		expected value:	0.000000
 
-constraint_messages_tests.c:121: Failure: FailureMessage -> for_violated_never_expect 
+constraint_messages_tests.c: Failure: FailureMessage -> for_violated_never_expect 
 	Mocked function [some_mock] has an expectation that it will never be called, but it was
 
-constraint_messages_tests.c:150: Failure: FailureMessage -> if_exception_was_expected_but_nothing_thrown 
-	Expected [(void)5] to throw [std::string]
+constraint_messages_tests.c: Failure: FailureMessage -> if_exception_was_expected_but_nothing_thrown 
+	Expected [(void)5] to throw [stdstring]
 
-constraint_messages_tests.c:140: Exception: FailureMessage -> increments_exception_count_when_terminating_via_SIGQUIT 
+constraint_messages_tests.c: Exception: FailureMessage -> increments_exception_count_when_terminating_via_SIGQUIT 
 	Test terminated with signal: Terminated
 
-constraint_messages_tests.c:153: Exception: FailureMessage -> increments_exception_count_when_throwing 
+constraint_messages_tests.c: Exception: FailureMessage -> increments_exception_count_when_throwing 
 	Test terminated unexpectedly, likely from a non-standard exception or Posix signal
 
 Completed "FailureMessage": 0 passes, 24 failures, 3 exceptions.

--- a/tests/constraint_messages_tests.c
+++ b/tests/constraint_messages_tests.c
@@ -52,8 +52,10 @@ Ensure(FailureMessage,for_is_equal_to_double) {
 }
 
 Ensure(FailureMessage,for_is_not_equal_to_double) {
-    double should_not_be_four_point_five = 4.5f, forty_five = 45;
-    assert_that_double(should_not_be_four_point_five, is_not_equal_to_double(forty_five));
+    significant_figures_for_assert_double_are(4);
+    double epsilon = 1.0e-4;
+    double four_point_five = 4.5, almost_four_point_five = 4.5 - epsilon;
+    assert_that_double(four_point_five, is_not_equal_to_double(almost_four_point_five));
 }
 
 Ensure(FailureMessage,for_is_greater_than_double) {

--- a/tests/constraint_messages_tests.c
+++ b/tests/constraint_messages_tests.c
@@ -5,6 +5,7 @@
 #include <cgreen/cgreen.h>
 #include <cgreen/mocks.h>
 #include <signal.h>
+#include <float.h>
 
 #ifdef __cplusplus
 using namespace cgreen;
@@ -43,6 +44,26 @@ Ensure(FailureMessage,for_is_greater_than) {
 Ensure(FailureMessage,for_is_less_than) {
     int fourty_five = 45, thirty_three = 33;
     assert_that(fourty_five, is_less_than(thirty_three));
+}
+
+Ensure(FailureMessage,for_is_equal_to_double) {
+    double four_point_five = 4.5f, three_point_three = 3.3f;
+    assert_that_double(four_point_five, is_equal_to_double(three_point_three));
+}
+
+Ensure(FailureMessage,for_is_not_equal_to_double) {
+    double should_not_be_four_point_five = 4.5f, forty_five = 45;
+    assert_that_double(should_not_be_four_point_five, is_not_equal_to_double(forty_five));
+}
+
+Ensure(FailureMessage,for_is_greater_than_double) {
+    double four_point_five = 4.5f, three_point_three = 3.3f;
+    assert_that_double(three_point_three, is_greater_than_double(four_point_five));
+}
+
+Ensure(FailureMessage,for_is_less_than_double) {
+    double four_point_five = 4.5f, three_point_three = 3.3f;
+    assert_that_double(four_point_five, is_less_than_double(three_point_three));
 }
 
 Ensure(FailureMessage,for_is_equal_to_contents_of) {
@@ -84,8 +105,26 @@ Ensure(FailureMessage,for_equal_to_double) {
   assert_that_double(0, is_equal_to_double(1));
 }
 
+Ensure(FailureMessage,for_equal_to_double_negative) {
+  assert_that_double(-1, is_equal_to_double(-2));
+}
+
 Ensure(FailureMessage,for_not_equal_to_double) {
   assert_that_double(0, is_not_equal_to_double(0));
+}
+
+Ensure(FailureMessage,for_not_equal_to_double_negative) {
+  assert_that_double(-1, is_not_equal_to_double(-1));
+}
+
+Ensure(FailureMessage,for_is_less_than_double_with_accuracy) {
+  significant_figures_for_assert_double_are(4);
+  assert_that_double(1.0, is_less_than_double(1.0 - 1.0e-3 - DBL_EPSILON));
+}
+
+Ensure(FailureMessage,for_is_greater_than_double_with_accuracy) {
+  significant_figures_for_assert_double_are(4);
+  assert_that_double(1.0, is_greater_than_double(1.0 + 1.0e-3 + DBL_EPSILON));
 }
 
 Ensure(FailureMessage,for_assert_that) {
@@ -170,6 +209,10 @@ TestSuite *all_constraints_tests() {
     add_test_with_context(suite, FailureMessage, for_is_not_equal_to);
     add_test_with_context(suite, FailureMessage, for_is_greater_than);
     add_test_with_context(suite, FailureMessage, for_is_less_than);
+    add_test_with_context(suite, FailureMessage, for_is_equal_to_double);
+    add_test_with_context(suite, FailureMessage, for_is_not_equal_to_double);
+    add_test_with_context(suite, FailureMessage, for_is_greater_than_double);
+    add_test_with_context(suite, FailureMessage, for_is_less_than_double);
     add_test_with_context(suite, FailureMessage, for_is_equal_to_contents_of);
     add_test_with_context(suite, FailureMessage, for_is_not_equal_to_contents_of);
     add_test_with_context(suite, FailureMessage, for_is_equal_to_string);
@@ -178,7 +221,11 @@ TestSuite *all_constraints_tests() {
     add_test_with_context(suite, FailureMessage, for_does_not_contain_string);
     add_test_with_context(suite, FailureMessage, for_begins_with_string);
     add_test_with_context(suite, FailureMessage, for_equal_to_double);
+    add_test_with_context(suite, FailureMessage, for_equal_to_double_negative);
     add_test_with_context(suite, FailureMessage, for_not_equal_to_double);
+    add_test_with_context(suite, FailureMessage, for_not_equal_to_double_negative);
+    add_test_with_context(suite, FailureMessage, for_is_less_than_double_with_accuracy);
+    add_test_with_context(suite, FailureMessage, for_is_greater_than_double_with_accuracy);
     add_test_with_context(suite, FailureMessage, for_assert_that);
     add_test_with_context(suite, FailureMessage, for_mock_called_with_unexpected_parameter_value);
     add_test_with_context(suite, FailureMessage, for_mock_called_more_times_than_expected);

--- a/tests/mock_messages.expected.c
+++ b/tests/mock_messages.expected.c
@@ -1,25 +1,25 @@
 Running "mock_messages" (6 tests)...
-mock_messages_tests.c:16: Failure: Mocks -> calls_beyond_expected_sequence_fail_when_mocks_are_strict 
+mock_messages_tests.c: Failure: Mocks -> calls_beyond_expected_sequence_fail_when_mocks_are_strict 
 	Mocked function [integer_out] was called too many times
 
-mock_messages_tests.c:46: Failure: Mocks -> calls_beyond_expected_sequence_fail_when_mocks_are_strict 
+mock_messages_tests.c: Failure: Mocks -> calls_beyond_expected_sequence_fail_when_mocks_are_strict 
 	Expected [integer_out()] to [equal] [3]
 		actual value:			[0]
 		expected value:			[3]
 
-mock_messages_tests.c:24: Failure: Mocks -> can_declare_function_never_called 
+mock_messages_tests.c: Failure: Mocks -> can_declare_function_never_called 
 	Mocked function [sample_mock] has an expectation that it will never be called, but it was
 
-mock_messages_tests.c:64: Failure: Mocks -> failure_reported_when_expect_after_always_expect_for_same_function 
+mock_messages_tests.c: Failure: Mocks -> failure_reported_when_expect_after_always_expect_for_same_function 
 	Mocked function [integer_out] already has an expectation that it will always be called a certain way; any expectations declared after an always expectation are invalid
 
-mock_messages_tests.c:56: Failure: Mocks -> failure_reported_when_expect_after_never_expect_for_same_function 
+mock_messages_tests.c: Failure: Mocks -> failure_reported_when_expect_after_never_expect_for_same_function 
 	Mocked function [integer_out] already has an expectation that it will never be called; any expectations declared after a never call expectation are invalid
 
-mock_messages_tests.c:16: Failure: Mocks -> failure_when_no_presets_for_default_strict_mock 
+mock_messages_tests.c: Failure: Mocks -> failure_when_no_presets_for_default_strict_mock 
 	Mocked function [integer_out] did not have an expectation that it would be called
 
-mock_messages_tests.c:72: Failure: Mocks -> single_uncalled_expectation_fails_tally 
+mock_messages_tests.c: Failure: Mocks -> single_uncalled_expectation_fails_tally 
 	Expected call was not made to mocked function [string_out]
 
 Completed "Mocks": 4 passes, 7 failures, 0 exceptions.

--- a/tests/mock_messages.expected.c++
+++ b/tests/mock_messages.expected.c++
@@ -1,25 +1,25 @@
 Running "mock_messages" (6 tests)...
-mock_messages_tests.c:16: Failure: Mocks -> calls_beyond_expected_sequence_fail_when_mocks_are_strict 
+mock_messages_tests.c: Failure: Mocks -> calls_beyond_expected_sequence_fail_when_mocks_are_strict 
 	Mocked function [integer_out] was called too many times
 
-mock_messages_tests.c:46: Failure: Mocks -> calls_beyond_expected_sequence_fail_when_mocks_are_strict 
+mock_messages_tests.c: Failure: Mocks -> calls_beyond_expected_sequence_fail_when_mocks_are_strict 
 	Expected [integer_out()] to [equal] [3]
 		actual value:			[0]
 		expected value:			[3]
 
-mock_messages_tests.c:24: Failure: Mocks -> can_declare_function_never_called 
+mock_messages_tests.c: Failure: Mocks -> can_declare_function_never_called 
 	Mocked function [sample_mock] has an expectation that it will never be called, but it was
 
-mock_messages_tests.c:64: Failure: Mocks -> failure_reported_when_expect_after_always_expect_for_same_function 
+mock_messages_tests.c: Failure: Mocks -> failure_reported_when_expect_after_always_expect_for_same_function 
 	Mocked function [integer_out] already has an expectation that it will always be called a certain way; any expectations declared after an always expectation are invalid
 
-mock_messages_tests.c:56: Failure: Mocks -> failure_reported_when_expect_after_never_expect_for_same_function 
+mock_messages_tests.c: Failure: Mocks -> failure_reported_when_expect_after_never_expect_for_same_function 
 	Mocked function [integer_out] already has an expectation that it will never be called; any expectations declared after a never call expectation are invalid
 
-mock_messages_tests.c:16: Failure: Mocks -> failure_when_no_presets_for_default_strict_mock 
+mock_messages_tests.c: Failure: Mocks -> failure_when_no_presets_for_default_strict_mock 
 	Mocked function [integer_out] did not have an expectation that it would be called
 
-mock_messages_tests.c:72: Failure: Mocks -> single_uncalled_expectation_fails_tally 
+mock_messages_tests.c: Failure: Mocks -> single_uncalled_expectation_fails_tally 
 	Expected call was not made to mocked function [string_out]
 
 Completed "Mocks": 4 passes, 7 failures, 0 exceptions.


### PR DESCRIPTION
Merged @matthargett:s double constraints, with @d-meiser:s fix for one of the tests. Also fixed the test output comparer regexp so that line numbers in the messages are not kept. That way it will be easier to compare, spot the *real* differences and merge in the future.