### PR TITLE
rebase of @doj 's sourceforge patch that adds test duration 

### DIFF
--- a/include/cgreen/internal/CMakeLists.txt
+++ b/include/cgreen/internal/CMakeLists.txt
@@ -9,6 +9,7 @@ set(cgreen_internal_HDRS
   c_assertions.h
   cpp_assertions.h
   cgreen_pipe.h
+  cgreen_time.h
   runner_platform.h
   function_macro.h
 )

--- a/include/cgreen/internal/cgreen_time.h
+++ b/include/cgreen/internal/cgreen_time.h
@@ -1,0 +1,20 @@
+#ifndef CGREEN_TIME_HEADER
+#define CGREEN_TIME_HEADER
+
+#include <stdint.h>
+#include <unistd.h>
+
+#ifdef __cplusplus
+namespace cgreen {
+    extern "C" {
+#endif
+
+uint32_t cgreen_time_get_current_milliseconds(void);
+uint32_t cgreen_time_duration_in_milliseconds(uint32_t start_time_in_milliseconds, uint32_t end_time_in_milliseconds);
+
+#ifdef __cplusplus
+    }
+}
+#endif
+
+#endif

--- a/include/cgreen/reporter.h
+++ b/include/cgreen/reporter.h
@@ -2,6 +2,7 @@
 #define REPORTER_HEADER
 
 #include <stdarg.h>
+#include <stdint.h>
 #include <cgreen/breadcrumb.h>
 
 #ifdef __cplusplus
@@ -18,8 +19,9 @@ struct TestReporter_ {
     void (*show_fail)(TestReporter *reporter, const char *file, int line, const char *message, va_list arguments);
     void (*show_incomplete)(TestReporter *reporter, const char *file, int line, const char *message, va_list arguments);
     void (*assert_true)(TestReporter *reporter, const char *file, int line, int result, const char * message, ...);
-    void (*finish_test)(TestReporter *reporter, const char *file, int line, const char *message);
-    void (*finish_suite)(TestReporter *reporter, const char *file, int line);
+    void (*finish_test)(TestReporter *reporter, const char *file, int line, const char *message,
+                        uint32_t duration_in_milliseconds);
+    void (*finish_suite)(TestReporter *reporter, const char *file, int line, uint32_t milliseconds);
     int passes;
     int failures;
     int exceptions;
@@ -46,8 +48,9 @@ void destroy_memo(TestReportMemo *memo);
 void reporter_start(TestReporter *reporter, const char *name);
 void reporter_start_suite(TestReporter *reporter, const char *name,
     const int count);
-void reporter_finish(TestReporter *reporter, const char *filename, int line, const char *message);
-void reporter_finish_suite(TestReporter *reporter, const char *filename, int line);
+void reporter_finish(TestReporter *reporter, const char *filename, int line, const char *message,
+                     uint32_t duration_in_milliseconds);
+void reporter_finish_suite(TestReporter *reporter, const char *filename, int line, uint32_t duration_in_milliseconds);
 void add_reporter_result(TestReporter *reporter, int result);
 void send_reporter_exception_notification(TestReporter *reporter);
 void send_reporter_completion_notification(TestReporter *reporter);

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -45,6 +45,7 @@ set(cgreen_SRCS
   assertions.c
   boxed_double.c
   breadcrumb.c
+  cgreen_time.c
   constraint.c
   constraint_syntax_helpers.c
   cute_reporter.c
@@ -65,6 +66,7 @@ set(cgreen_SRCS
 if (UNIX)
   LIST(APPEND cgreen_SRCS 
     posix_cgreen_pipe.c
+    posix_cgreen_time.c
     posix_runner_platform.c
   )
 else(UNIX)

--- a/src/cdash_reporter.c
+++ b/src/cdash_reporter.c
@@ -43,8 +43,10 @@ static void show_failed(TestReporter *reporter, const char *file, int line, cons
 static void show_passed(TestReporter *reporter, const char *file, int line, const char *message, va_list arguments);
 static void show_incomplete(TestReporter *reporter, const char *file, int line, const char *message, va_list arguments);
 
-static void cdash_reporter_testcase_finished(TestReporter *reporter, const char *filename, int line, const char *message);
-static void cdash_reporter_suite_finished(TestReporter *reporter, const char *filename, int line);
+static void cdash_reporter_testcase_finished(TestReporter *reporter, const char *filename, int line,
+                                             const char *message, uint32_t duration_in_milliseconds);
+static void cdash_reporter_suite_finished(TestReporter *reporter, const char *filename, int line,
+                                          uint32_t duration_in_milliseconds);
 
 static time_t cdash_build_stamp(char *sbuildstamp, size_t sb);
 static time_t cdash_current_time(char *strtime);
@@ -256,13 +258,15 @@ static void show_incomplete(TestReporter *reporter, const char *file, int line, 
 }
 
 
-static void cdash_reporter_testcase_finished(TestReporter *reporter, const char *filename, int line, const char *message) {
-    reporter_finish(reporter, filename, line, message);
+static void cdash_reporter_testcase_finished(TestReporter *reporter, const char *filename, int line,
+                                             const char *message, uint32_t duration_in_milliseconds) {
+    reporter_finish(reporter, filename, line, message, duration_in_milliseconds);
 }
 
 
-static void cdash_reporter_suite_finished(TestReporter *reporter, const char *filename, int line) {
-    reporter_finish(reporter, filename, line, NULL);
+static void cdash_reporter_suite_finished(TestReporter *reporter, const char *filename, int line,
+                                          uint32_t duration_in_milliseconds) {
+    reporter_finish(reporter, filename, line, NULL, duration_in_milliseconds);
 }
 
 static time_t cdash_build_stamp(char *sbuildstamp, size_t sb) {

--- a/src/cgreen_time.c
+++ b/src/cgreen_time.c
@@ -1,0 +1,20 @@
+#include "cgreen/internal/cgreen_time.h"
+#include <stdint.h>
+
+#ifdef __cplusplus
+namespace cgreen {
+#endif
+
+uint32_t cgreen_time_duration_in_milliseconds(uint32_t start_time_in_milliseconds, uint32_t end_time_in_milliseconds) {
+    if (end_time_in_milliseconds < start_time_in_milliseconds) {
+        return 0;
+    }
+
+    return end_time_in_milliseconds - start_time_in_milliseconds;
+}
+
+#ifdef __cplusplus
+}  // namespace cgreen
+#endif
+
+

--- a/src/posix_cgreen_pipe.c
+++ b/src/posix_cgreen_pipe.c
@@ -9,7 +9,7 @@
 #ifndef O_ASYNC
 #  define O_ASYNC FASYNC
 #  ifndef FASYNC
-#    error "Your POSIX platform does not support ASYNC pipe reads. Please report a bug to cgreen-devel@lists.sf.net"
+#    error "Your POSIX platform does not support ASYNC pipe reads. Please report a bug to http://github.com/cgreen-devs/cgreen/issues"
 #  endif
 #endif
 

--- a/src/posix_cgreen_time.c
+++ b/src/posix_cgreen_time.c
@@ -1,0 +1,33 @@
+#include "cgreen/internal/cgreen_time.h"
+#include <stdint.h>
+#include <stdio.h>
+#include <unistd.h>
+
+#if defined(__FreeBSD__) || defined(__linux__) || defined(__APPLE__)
+#  include <sys/time.h>
+#  define HAVE_GETTIMEOFDAY 1
+#else
+#  error "Your POSIX platform does not support gettimeofday(). Please report a bug to http://github.com/cgreen-devs/cgreen/issues"
+#endif
+
+#ifdef __cplusplus
+namespace cgreen {
+#endif
+
+#if defined(HAVE_GETTIMEOFDAY)
+uint32_t cgreen_time_get_current_milliseconds() {
+    struct timeval tv;
+    if (gettimeofday(&tv, NULL) != 0) {
+        fprintf(stderr, "cgreen error: could not get time of day\n");
+        return 0;
+    }
+
+    return tv.tv_sec * 1000u + tv.tv_usec / 1000u;
+}
+#endif
+
+#ifdef __cplusplus
+} // namespace cgreen
+#endif
+
+/* vim: set ts=4 sw=4 et cindent: */

--- a/src/reporter.c
+++ b/src/reporter.c
@@ -98,7 +98,9 @@ void reporter_start_suite(TestReporter *reporter, const char *name, const int co
     reporter_start(reporter, name);
 }
 
-void reporter_finish(TestReporter *reporter, const char *filename, int line, const char *message) {
+void reporter_finish(TestReporter *reporter, const char *filename, int line, const char *message,
+                     uint32_t duration_in_milliseconds) {
+    (void)duration_in_milliseconds;
     int status = read_reporter_results(reporter);
 
     if (status == FINISH_NOTIFICATION_NOT_RECEIVED) {
@@ -111,11 +113,14 @@ void reporter_finish(TestReporter *reporter, const char *filename, int line, con
     pop_breadcrumb((CgreenBreadcrumb *)reporter->breadcrumb);
 }
 
-void reporter_finish_suite(TestReporter *reporter, const char *filename, int line) {
-    (void) filename;
-    (void) line;
+void reporter_finish_suite(TestReporter *reporter, const char *filename, int line, uint32_t duration_in_milliseconds) {
+    (void)filename;
+    (void)line;
+    (void)duration_in_milliseconds;
+
     read_reporter_results(reporter);
     pop_breadcrumb((CgreenBreadcrumb *)reporter->breadcrumb);
+
 }
 
 void add_reporter_result(TestReporter *reporter, int result) {

--- a/src/text_reporter.c
+++ b/src/text_reporter.c
@@ -21,13 +21,14 @@ static void text_reporter_start_suite(TestReporter *reporter, const char *name,
 		const int number_of_tests);
 static void text_reporter_start_test(TestReporter *reporter, const char *name);
 static void text_reporter_finish(TestReporter *reporter, const char *filename,
-		int line, const char *message);
+		int line, const char *message, uint32_t duration_in_milliseconds);
 static void show_fail(TestReporter *reporter, const char *file, int line,
 		const char *message, va_list arguments);
 static void show_incomplete(TestReporter *reporter, const char *file, int line,
 		const char *message, va_list arguments);
 static void show_breadcrumb(const char *name, void *memo);
-static void text_reporter_finish_suite(TestReporter *reporter, const char *file, int line);
+static void text_reporter_finish_suite(TestReporter *reporter, const char *file, int line,
+									   uint32_t duration_in_milliseconds);
 
 TestReporter *create_text_reporter(void) {
 	TestReporter *reporter = create_reporter();
@@ -60,26 +61,31 @@ static void text_reporter_start_test(TestReporter *reporter, const char *name) {
 }
 
 static void text_reporter_finish(TestReporter *reporter, const char *filename,
-		int line, const char *message) {
-	reporter_finish(reporter, filename, line, message);
+		int line, const char *message, uint32_t duration_in_milliseconds) {
+	reporter_finish(reporter, filename, line, message, duration_in_milliseconds);
 }
 
-static void text_reporter_finish_suite(TestReporter *reporter, const char *file, int line) {
+static void text_reporter_finish_suite(TestReporter *reporter, const char *file, int line, uint32_t duration_in_milliseconds) {
 	const char *name = get_current_from_breadcrumb((CgreenBreadcrumb *) reporter->breadcrumb);
 
-    reporter_finish_suite(reporter, file, line);
+    reporter_finish_suite(reporter, file, line, duration_in_milliseconds);
 
-    if (reporter->options && ((TextReporterOptions *)reporter->options)->use_colours)
-        printf("Completed \"%s\": %s%d pass%s%s, %s%d failure%s%s, %s%d exception%s%s.\n",
+    if (reporter->options && ((TextReporterOptions *)reporter->options)->use_colours) {
+        printf("Completed \"%s\": %s%d pass%s%s, %s%d failure%s%s, %s%d exception%s%s, duration %d ms.\n",
                name,
-			   (reporter->passes > 0) ? GREEN : "", reporter->passes, reporter->passes == 1 ? "" : "es", RESET, 
+               (reporter->passes > 0) ? GREEN : "", reporter->passes, reporter->passes == 1 ? "" : "es", RESET,
                (reporter->failures > 0) ? RED : "", reporter->failures, reporter->failures == 1 ? "" : "s", RESET,
-               (reporter->exceptions > 0) ? MAGENTA : "", reporter->exceptions, reporter->exceptions == 1 ? "" : "s", RESET);
-    else
-        printf("Completed \"%s\": %d pass%s, %d failure%s, %d exception%s.\n",
-               name, reporter->passes, reporter->passes == 1 ? "" : "es",
-               reporter->failures, reporter->failures == 1 ? "" : "s",
-               reporter->exceptions, reporter->exceptions == 1 ? "" : "s");
+               (reporter->exceptions > 0) ? MAGENTA : "", reporter->exceptions, reporter->exceptions == 1 ? "" : "s",
+               RESET,
+               duration_in_milliseconds);
+        return;
+    }
+
+    printf("Completed \"%s\": %d pass%s, %d failure%s, %d exception%s, %d ms.\n",
+            name, reporter->passes, reporter->passes == 1 ? "" : "es",
+            reporter->failures, reporter->failures == 1 ? "" : "s",
+            reporter->exceptions, reporter->exceptions == 1 ? "" : "s",
+            duration_in_milliseconds);
 }
 
 static void show_fail(TestReporter *reporter, const char *file, int line,

--- a/tests/cute_reporter_tests.c
+++ b/tests/cute_reporter_tests.c
@@ -10,6 +10,8 @@
 using namespace cgreen;
 #endif
 
+static const int line=666;
+static const uint32_t duration_in_milliseconds = 1;
 static char *output = NULL;
 
 static void clear_output()
@@ -85,7 +87,6 @@ Ensure(CuteReporter, will_report_beginning_of_suite) {
 
 Ensure(CuteReporter, will_report_beginning_and_successful_finishing_of_test) {
     va_list arguments;
-    const int line=666;
 
     reporter->start_test(reporter, "test_name");
     assert_that(output, begins_with_string("#starting"));
@@ -99,14 +100,13 @@ Ensure(CuteReporter, will_report_beginning_and_successful_finishing_of_test) {
 
     // Must indicate test case completion before calling finish_test()
     send_reporter_completion_notification(reporter);
-    reporter->finish_test(reporter, "filename", line, NULL);
+    reporter->finish_test(reporter, "filename", line, NULL, duration_in_milliseconds);
     assert_that(output, begins_with_string("#success"));
     assert_that(output, contains_string("test_name"));
 }
 
 Ensure(CuteReporter, will_report_failing_of_test_only_once) {
     va_list arguments;
-    const int line = 666;
 
     reporter->start_test(reporter, "test_name");
 
@@ -124,16 +124,16 @@ Ensure(CuteReporter, will_report_failing_of_test_only_once) {
 
     // Must indicate test case completion before calling finish_test()
     send_reporter_completion_notification(reporter);
-    reporter->finish_test(reporter, "filename", line, NULL);
+    reporter->finish_test(reporter, "filename", line, NULL, duration_in_milliseconds);
     assert_no_output();
 }
 
 Ensure(CuteReporter, will_report_finishing_of_suite) {
-    const int line = 666;
+    // Must indicate test suite completion before calling finish_suite()
     reporter_start(reporter, "suite_name");
 
     send_reporter_completion_notification(reporter);
-    reporter->finish_suite(reporter, "filename", line);
+    reporter->finish_suite(reporter, "filename", line, duration_in_milliseconds);
 
     assert_that(output, begins_with_string("#ending"));
     assert_that(output, contains_string("suite_name"));
@@ -144,7 +144,7 @@ Ensure(CuteReporter, will_report_non_finishing_test) {
     reporter_start(reporter, "suite_name");
 
     send_reporter_exception_notification(reporter);
-    reporter->finish_suite(reporter, "filename", line);
+    reporter->finish_suite(reporter, "filename", line, duration_in_milliseconds);
 
     assert_that(output, begins_with_string("#error"));
     assert_that(output, contains_string("failed to complete"));

--- a/tools/xml_reporter.c
+++ b/tools/xml_reporter.c
@@ -3,14 +3,17 @@
 #include "cgreen/breadcrumb.h"
 
 #include <stdio.h>
+#include <stdint.h>
 #include <stdlib.h>
 #include <string.h>
 #include <errno.h>
 
 static void xml_reporter_start_suite(TestReporter *reporter, const char *name, int count);
 static void xml_reporter_start_test(TestReporter *reporter, const char *name);
-static void xml_reporter_finish_test(TestReporter *reporter, const char *filename, int line, const char *message);
-static void xml_reporter_finish_suite(TestReporter *reporter, const char *filename, int line);
+static void xml_reporter_finish_test(TestReporter *reporter, const char *filename, int line, const char *message,
+                                     uint32_t duration_in_milliseconds);
+static void xml_reporter_finish_suite(TestReporter *reporter, const char *filename, int line,
+                                      uint32_t duration_in_milliseconds);
 static void xml_show_fail(TestReporter *reporter, const char *file, int line, const char *message, va_list arguments);
 static void xml_show_incomplete(TestReporter *reporter, const char *filename, int line, const char *message, va_list arguments);
 
@@ -107,17 +110,19 @@ static void xml_show_incomplete(TestReporter *reporter, const char *filename, in
     fflush(out);
 }
 
-static void xml_reporter_finish_test(TestReporter *reporter, const char *filename, int line, const char *message) {
+static void xml_reporter_finish_test(TestReporter *reporter, const char *filename, int line, const char *message,
+                                     uint32_t duration_in_milliseconds) {
     FILE *out = file_stack[file_stack_p-1];
-    reporter_finish(reporter, filename, line, message);
+    reporter_finish(reporter, filename, line, message, duration_in_milliseconds);
     indent(out, reporter);
     fprintf(out, "</testcase>\n");
     fflush(out);
 }
 
-static void xml_reporter_finish_suite(TestReporter *reporter, const char *filename, int line) {
+static void xml_reporter_finish_suite(TestReporter *reporter, const char *filename, int line,
+                                      uint32_t duration_in_milliseconds) {
     FILE *out = file_stack[--file_stack_p];
-    reporter_finish_suite(reporter, filename, line);
+    reporter_finish_suite(reporter, filename, line, duration_in_milliseconds);
     indent(out, reporter);
     fprintf(out, "</testsuite>\n");
     fclose(out);


### PR DESCRIPTION
in millieconds to reporters.  only added the POSIX bits since I don't have Windows machine readily available to test and have no space on my dev machine to copy over a Windows dev VM. Some minor structural changes versus his approach. Open question: why can't we store the runtime for each test in its struct and then add up the test runtimes in finish_suite?

The integration tests that compare golden output files will also need to be changed/loosened to overlook the specific millisecond values. 