### PR TITLE
Improved message for [not equal to content of] when content *is* the same

### DIFF
--- a/doc/cgreen-guide-en.asciidoc
+++ b/doc/cgreen-guide-en.asciidoc
@@ -1017,8 +1017,13 @@ suite has problems.
 
 Of course, if you want to set a general time limit on all your tests,
 then you can add a `die_in()` to a `BeforeEach()` (or `setup()`)
-function. *Cgreen* will then apply the limit to each of the tests, of
-course.
+function. *Cgreen* will then apply the limit to each of the tests in
+that context, of course.
+
+Another possibility is the use of an environment variable named
+`CGREEN_TIMEOUT_PER_TEST` which, if set to a number will apply that
+timeout to every test run. This will apply to all tests in the same
+run.
 
 Building composite test suites
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/src/assertions.c
+++ b/src/assertions.c
@@ -83,7 +83,7 @@ void assert_that_double_(const char *file, int line, const char *expression, dou
     (*get_test_reporter()->assert_true)(get_test_reporter(), file, line, (*constraint->compare)(constraint, (intptr_t)boxed_actual),
             "Expected [%s] to [%s] [%s] within [%d] significant figures\n"
             "\t\tactual value:\t%08f\n"
-            "\t\texpected value:\t%08f\n",
+            "\t\texpected value:\t%08f",
             expression,
             constraint->name,
             constraint->expected_value_name,

--- a/src/message_formatting.c
+++ b/src/message_formatting.c
@@ -235,10 +235,11 @@ char *failure_message_for(Constraint *constraint, const char *actual_string, int
     if (is_content_comparing(constraint)) {
         int difference_index = find_index_of_difference((char *)constraint->expected_value,
                                                         (char *)actual, constraint->size_of_expected_value);
-        if (difference_index != -1)
+        if (difference_index != -1) {
             snprintf(message + strlen(message), message_size - strlen(message) - 1,
                      at_offset,
                      difference_index);
+        }
         return message;
     }
 

--- a/src/message_formatting.c
+++ b/src/message_formatting.c
@@ -166,10 +166,10 @@ void double_all_percent_signs_in(char **original)
 char *failure_message_for(Constraint *constraint, const char *actual_string, intptr_t actual) {
     char actual_value_string[32];
     const char *actual_value_constraint_name = "Expected [%s] to [%s]";
-    const char *expected_value_name =  "[%s]\n";
-    const char *actual_value_as_string = "\t\tactual value:\t\t\t[\"%s\"]";
-    const char *at_offset = "\t\tat offset:\t\t\t[%d]";
-    const char *actual_value_message = "\t\tactual value:\t\t\t[%" PRIdPTR "]";
+    const char *expected_value_name =  "[%s]";
+    const char *actual_value_as_string = "\n\t\tactual value:\t\t\t[\"%s\"]";
+    const char *at_offset = "\n\t\tat offset:\t\t\t[%d]";
+    const char *actual_value_message = "\n\t\tactual value:\t\t\t[%" PRIdPTR "]";
     char *message;
     size_t message_size = strlen(actual_value_constraint_name) +
     		strlen(expected_value_name) +
@@ -235,9 +235,10 @@ char *failure_message_for(Constraint *constraint, const char *actual_string, int
     if (is_content_comparing(constraint)) {
         int difference_index = find_index_of_difference((char *)constraint->expected_value,
                                                         (char *)actual, constraint->size_of_expected_value);
-        snprintf(message + strlen(message), message_size - strlen(message) - 1,
-                 at_offset,
-                 difference_index);
+        if (difference_index != -1)
+            snprintf(message + strlen(message), message_size - strlen(message) - 1,
+                     at_offset,
+                     difference_index);
         return message;
     }
 

--- a/tests/constraint_messages.c++.expected
+++ b/tests/constraint_messages.c++.expected
@@ -25,12 +25,10 @@ constraint_messages_tests.c: Failure: FailureMessage -> for_equal_to_double
 		actual value:	0.000000
 		expected value:	1.000000
 
-
 constraint_messages_tests.c: Failure: FailureMessage -> for_equal_to_double_negative 
 	Expected [-1] to [equal double] [-2] within [8] significant figures
 		actual value:	-1.000000
 		expected value:	-2.000000
-
 
 constraint_messages_tests.c: Exception: FailureMessage -> for_incorrect_assert_throws 
 	an exception was thrown during test: [something else]
@@ -49,7 +47,6 @@ constraint_messages_tests.c: Failure: FailureMessage -> for_is_equal_to_double
 		actual value:	4.500000
 		expected value:	3.300000
 
-
 constraint_messages_tests.c: Failure: FailureMessage -> for_is_equal_to_string 
 	Expected [thirty_three] to [equal string] [fourty_five]
 		actual value:			["this string is thirtythree"]
@@ -65,12 +62,10 @@ constraint_messages_tests.c: Failure: FailureMessage -> for_is_greater_than_doub
 		actual value:	3.300000
 		expected value:	4.500000
 
-
 constraint_messages_tests.c: Failure: FailureMessage -> for_is_greater_than_double_with_accuracy 
 	Expected [1.0] to [be greater than double] [1.0 + 1.0e-3 + DBL_EPSILON] within [4] significant figures
 		actual value:	1.000000
 		expected value:	1.001000
-
 
 constraint_messages_tests.c: Failure: FailureMessage -> for_is_less_than 
 	Expected [fourty_five] to [be less than] [thirty_three]
@@ -82,12 +77,10 @@ constraint_messages_tests.c: Failure: FailureMessage -> for_is_less_than_double
 		actual value:	4.500000
 		expected value:	3.300000
 
-
 constraint_messages_tests.c: Failure: FailureMessage -> for_is_less_than_double_with_accuracy 
 	Expected [1.0] to [be less than double] [1.0 - 1.0e-3 - DBL_EPSILON] within [4] significant figures
 		actual value:	1.000000
 		expected value:	0.999000
-
 
 constraint_messages_tests.c: Failure: FailureMessage -> for_is_non_null 
 	Expected [pointer] to [be non null]
@@ -98,13 +91,11 @@ constraint_messages_tests.c: Failure: FailureMessage -> for_is_not_equal_to
 
 constraint_messages_tests.c: Failure: FailureMessage -> for_is_not_equal_to_contents_of 
 	Expected [fourty_five_and_up] to [not equal contents of] [another_fourty_five_and_up]
-		at offset:			[-1]
 
 constraint_messages_tests.c: Failure: FailureMessage -> for_is_not_equal_to_double 
 	Expected [four_point_five] to [not equal double] [almost_four_point_five] within [4] significant figures
 		actual value:	4.500000
 		expected value:	4.499900
-
 
 constraint_messages_tests.c: Failure: FailureMessage -> for_is_not_equal_to_string 
 	Expected [another_fourty_five] to [not equal string] [fourty_five]
@@ -135,12 +126,10 @@ constraint_messages_tests.c: Failure: FailureMessage -> for_not_equal_to_double
 		actual value:	0.000000
 		expected value:	0.000000
 
-
 constraint_messages_tests.c: Failure: FailureMessage -> for_not_equal_to_double_negative 
 	Expected [-1] to [not equal double] [-1] within [8] significant figures
 		actual value:	-1.000000
 		expected value:	-1.000000
-
 
 constraint_messages_tests.c: Failure: FailureMessage -> for_violated_never_expect 
 	Mocked function [some_mock] has an expectation that it will never be called, but it was

--- a/tests/constraint_messages.c.expected
+++ b/tests/constraint_messages.c.expected
@@ -25,12 +25,10 @@ constraint_messages_tests.c: Failure: FailureMessage -> for_equal_to_double
 		actual value:	0.000000
 		expected value:	1.000000
 
-
 constraint_messages_tests.c: Failure: FailureMessage -> for_equal_to_double_negative 
 	Expected [-1] to [equal double] [-2] within [8] significant figures
 		actual value:	-1.000000
 		expected value:	-2.000000
-
 
 constraint_messages_tests.c: Failure: FailureMessage -> for_is_equal_to 
 	Expected [fourty_five] to [equal] [thirty_three]
@@ -45,7 +43,6 @@ constraint_messages_tests.c: Failure: FailureMessage -> for_is_equal_to_double
 	Expected [four_point_five] to [equal double] [three_point_three] within [8] significant figures
 		actual value:	4.500000
 		expected value:	3.300000
-
 
 constraint_messages_tests.c: Failure: FailureMessage -> for_is_equal_to_string 
 	Expected [thirty_three] to [equal string] [fourty_five]
@@ -62,12 +59,10 @@ constraint_messages_tests.c: Failure: FailureMessage -> for_is_greater_than_doub
 		actual value:	3.300000
 		expected value:	4.500000
 
-
 constraint_messages_tests.c: Failure: FailureMessage -> for_is_greater_than_double_with_accuracy 
 	Expected [1.0] to [be greater than double] [1.0 + 1.0e-3 + DBL_EPSILON] within [4] significant figures
 		actual value:	1.000000
 		expected value:	1.001000
-
 
 constraint_messages_tests.c: Failure: FailureMessage -> for_is_less_than 
 	Expected [fourty_five] to [be less than] [thirty_three]
@@ -79,12 +74,10 @@ constraint_messages_tests.c: Failure: FailureMessage -> for_is_less_than_double
 		actual value:	4.500000
 		expected value:	3.300000
 
-
 constraint_messages_tests.c: Failure: FailureMessage -> for_is_less_than_double_with_accuracy 
 	Expected [1.0] to [be less than double] [1.0 - 1.0e-3 - DBL_EPSILON] within [4] significant figures
 		actual value:	1.000000
 		expected value:	0.999000
-
 
 constraint_messages_tests.c: Failure: FailureMessage -> for_is_non_null 
 	Expected [pointer] to [be non null]
@@ -95,13 +88,11 @@ constraint_messages_tests.c: Failure: FailureMessage -> for_is_not_equal_to
 
 constraint_messages_tests.c: Failure: FailureMessage -> for_is_not_equal_to_contents_of 
 	Expected [fourty_five_and_up] to [not equal contents of] [another_fourty_five_and_up]
-		at offset:			[-1]
 
 constraint_messages_tests.c: Failure: FailureMessage -> for_is_not_equal_to_double 
 	Expected [four_point_five] to [not equal double] [almost_four_point_five] within [4] significant figures
 		actual value:	4.500000
 		expected value:	4.499900
-
 
 constraint_messages_tests.c: Failure: FailureMessage -> for_is_not_equal_to_string 
 	Expected [another_fourty_five] to [not equal string] [fourty_five]
@@ -132,12 +123,10 @@ constraint_messages_tests.c: Failure: FailureMessage -> for_not_equal_to_double
 		actual value:	0.000000
 		expected value:	0.000000
 
-
 constraint_messages_tests.c: Failure: FailureMessage -> for_not_equal_to_double_negative 
 	Expected [-1] to [not equal double] [-1] within [8] significant figures
 		actual value:	-1.000000
 		expected value:	-1.000000
-
 
 constraint_messages_tests.c: Failure: FailureMessage -> for_violated_never_expect 
 	Mocked function [some_mock] has an expectation that it will never be called, but it was


### PR DESCRIPTION
... by removing the "at index: -1" line. So this fixes #14.

Moved some newlines around and removed some to unify spacing to a single empty line between messages. Specifically for the new messages for double.

Also documented the CGREEN_TIMEOUT_PER_TEST environment variable as a bonus.