### PR TITLE
Fixed #37 - single mock() argument was not cast

### DIFF
--- a/include/cgreen/internal/mock_table.h
+++ b/include/cgreen/internal/mock_table.h
@@ -35,7 +35,7 @@
 
 //mock1 works for 1 or 0
 #define mock1(test_reporter, function_name, mock_file, mock_line, arguments_string, ...)\
-  mock_(test_reporter, function_name, mock_file, mock_line, arguments_string, __VA_ARGS__)
+    mock_(test_reporter, function_name, mock_file, mock_line, arguments_string, (intptr_t)__VA_ARGS__)
 
 #define PP_RSEQ_N() \
 	mock63, mock62, mock61, mock60, mock59, mock58, mock57, mock56, mock55, mock54,\

--- a/tools/tests/runnerTests.c
+++ b/tools/tests/runnerTests.c
@@ -3,7 +3,7 @@
 #include "utils.h"
 
 #ifdef __cplusplus
-namespace cgreen {
+using namespace cgreen;
 #endif
 
 #include "../runner.c"
@@ -139,10 +139,6 @@ Ensure(Runner, can_add_test_to_the_suite_for_its_context) {
     destroy_context_suites(suite_list);
 }
 
-
-#ifdef __cplusplus
-} // namespace cgreen
-#endif
 
 /* vim: set ts=4 sw=4 et cindent: */
 /* Local variables: */


### PR DESCRIPTION
On Cygwin64 `uintptr_t` is longer than `int` which requires that all actual parameters need to be cast. They where, except for the case of a single argument. So this fixes #37.

Also applied the NM_COLUMN_SEPARATORS in order during runtime so we need not update any ifdefs if some platform changes (which is what seems to have happened on cygwin64 as opposed to cygwin32.