### PR TITLE
Added a first assertion message output test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -64,6 +64,8 @@ unit:
 		constraint_messages ../../tests/constraint_messages.$$d.expected s%$$DIR%%g ; \
 	  CGREEN_PER_TEST_TIMEOUT=1 ../../tools/cgreen_runner_output_diff tools `find tests -name '$(PREFIX)failure_messages$(SUFFIX)'` \
 		failure_messages ../../tests/failure_messages.$$d.expected s%$${DIR}%%g ; \
+	  ../../tools/cgreen_runner_output_diff tools `find tests -name '$(PREFIX)assertion_messages$(SUFFIX)'` \
+		assertion_messages ../../tests/assertion_messages.$$d.expected s%$${DIR}%%g ; \
 	  cd ../.. ; \
 	done
 

--- a/src/message_formatting.c
+++ b/src/message_formatting.c
@@ -50,7 +50,7 @@ bool parameters_are_not_valid_for(Constraint *constraint, intptr_t actual) {
 
 char *validation_failure_message_for(Constraint *constraint, intptr_t actual) {
     const char *name_has_incorrect_size_message =
-    		"\t\tWanted to compare contents with [%s], but [%lu] was given for the comparison size.";
+    		"\t\tWanted to compare contents with [%s], but [%ld] was given for the comparison size.";
     const char *null_used_for_compare_message =
             "\t\tWanted to compare contents with [%s], but NULL was used for the pointer we wanted to compare to."
             "\t\tIf you want to explicitly check for null, use the is_null constraint instead.";
@@ -83,11 +83,11 @@ char *validation_failure_message_for(Constraint *constraint, intptr_t actual) {
             compared_to_name = constraint->expected_value_name;
         }
 
-        if (constraint->size_of_expected_value <= 0) {
+        if ((long signed)constraint->size_of_expected_value <= 0) {
             snprintf(message + strlen(message), message_size - strlen(message) - 1,
                     name_has_incorrect_size_message,
                     compared_to_name,
-                    (unsigned long)constraint->size_of_expected_value);
+                    (long signed)constraint->size_of_expected_value);
 
             return message;
         }

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -62,17 +62,26 @@ set(failure_messages_library
 set(failure_messages_library_SRCS
   failure_messages_tests.c)
 
+set(assertion_messages_library
+  assertion_messages
+)
+
+set(assertion_messages_library_SRCS
+  assertion_messages_tests.c)
+
 if (CGREEN_WITH_CXX)
   SET_SOURCE_FILES_PROPERTIES( ${test_SRCS} PROPERTIES LANGUAGE CXX )
   SET_SOURCE_FILES_PROPERTIES( ${constraint_messages_library_SRCS} PROPERTIES LANGUAGE CXX )
   SET_SOURCE_FILES_PROPERTIES( ${mock_messages_library_SRCS} PROPERTIES LANGUAGE CXX )
   SET_SOURCE_FILES_PROPERTIES( ${failure_messages_library_SRCS} PROPERTIES LANGUAGE CXX )
+  SET_SOURCE_FILES_PROPERTIES( ${assertion_messages_library_SRCS} PROPERTIES LANGUAGE CXX )
 endif (CGREEN_WITH_CXX)
 
 add_library(${CGREEN_TEST_LIBRARY} SHARED ${test_library_SRCS})
 add_library(${constraint_messages_library} SHARED ${constraint_messages_library_SRCS})
 add_library(${mock_messages_library} SHARED ${mock_messages_library_SRCS})
 add_library(${failure_messages_library} SHARED ${failure_messages_library_SRCS})
+add_library(${assertion_messages_library} SHARED ${assertion_messages_library_SRCS})
 
 if (CGREEN_WITH_STATIC_LIBRARY)
   set(CGREEN_LIBRARY ${CGREEN_STATIC_LIBRARY})
@@ -85,11 +94,13 @@ if (CGREEN_WITH_CXX)
   target_link_libraries(${constraint_messages_library} ${CGREEN_LIBRARY} ${CMAKE_CXX_IMPLICIT_LINK_LIBRARIES})
   target_link_libraries(${mock_messages_library} ${CGREEN_LIBRARY} ${CMAKE_CXX_IMPLICIT_LINK_LIBRARIES})
   target_link_libraries(${failure_messages_library} ${CGREEN_LIBRARY} ${CMAKE_CXX_IMPLICIT_LINK_LIBRARIES})
+  target_link_libraries(${assertion_messages_library} ${CGREEN_LIBRARY} ${CMAKE_CXX_IMPLICIT_LINK_LIBRARIES})
 else()
   target_link_libraries(${CGREEN_TEST_LIBRARY} ${CGREEN_LIBRARY})
   target_link_libraries(${constraint_messages_library} ${CGREEN_LIBRARY})
   target_link_libraries(${mock_messages_library} ${CGREEN_LIBRARY})
   target_link_libraries(${failure_messages_library} ${CGREEN_LIBRARY})
+  target_link_libraries(${assertion_messages_library} ${CGREEN_LIBRARY})
 endif (CGREEN_WITH_CXX)
 
 if (CGREEN_WITH_CXX)
@@ -150,6 +161,20 @@ macro_add_test(NAME failure_messages
             ${failure_messages_library}
             # ... then compare it to
             ${CMAKE_CURRENT_SOURCE_DIR}/${failure_messages_library}.${LANG}.expected
+            # ... but execute the following extra SED commands on the output before making the comparison
+            ${IGNORE_SOURCE_PATH_REGEX}
+)
+
+macro_add_test(NAME assertion_messages
+    COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/../tools/cgreen_runner_output_diff
+            # Run the runner in directory
+            ${CMAKE_CURRENT_BINARY_DIR}/../tools
+            # .. on library
+            $<TARGET_FILE_NAME:${assertion_messages_library}>
+            # ... storing the output in an output file with basename
+            ${assertion_messages_library}
+            # ... then compare it to
+            ${CMAKE_CURRENT_SOURCE_DIR}/${assertion_messages_library}.${LANG}.expected
             # ... but execute the following extra SED commands on the output before making the comparison
             ${IGNORE_SOURCE_PATH_REGEX}
 )

--- a/tests/accept_output_for
+++ b/tests/accept_output_for
@@ -1,0 +1,27 @@
+#!/bin/bash
+#
+# Script to accept the current output for some output comparing test as the golden output
+#
+#   Usage: accept <test> <lang>
+#
+# Will copy build/build-<lang>/tests/<test>.output to tests/<test>.<lang>.expected
+
+if [ "$#" -ne 2 ]
+then
+  echo "Usage: accept <test> <lang>"
+  exit 1
+fi
+
+scriptdir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+rootdir=$(dirname $scriptdir)
+
+echo "About to 'cp build/build-$2/tests/$1.output tests/$1.$2.expected'"
+
+read -r -p "Are you sure? [y/N] " response
+if [[ ! $response =~ ^([yY][eE][sS]|[yY])$ ]]
+then
+    exit
+fi
+
+cp $rootdir/build/build-$2/tests/$1.output $rootdir/tests/$1.$2.expected
+echo "Copied!"

--- a/tests/assertion_messages.c++.expected
+++ b/tests/assertion_messages.c++.expected
@@ -1,0 +1,6 @@
+Running "assertion_messages" (1 tests)...
+assertion_messages_tests.c: Failure: AssertionMessage -> for_comparing_content_with_negative_length 
+			Wanted to compare contents with [something], but [-4] was given for the comparison size.
+
+Completed "AssertionMessage": 0 passes, 1 failure, 0 exceptions in 0ms.
+Completed "assertion_messages": 0 passes, 1 failure, 0 exceptions in 0ms.

--- a/tests/assertion_messages.c.expected
+++ b/tests/assertion_messages.c.expected
@@ -1,0 +1,6 @@
+Running "assertion_messages" (1 tests)...
+assertion_messages_tests.c: Failure: AssertionMessage -> for_comparing_content_with_negative_length 
+			Wanted to compare contents with [something], but [-4] was given for the comparison size.
+
+Completed "AssertionMessage": 0 passes, 1 failure, 0 exceptions in 0ms.
+Completed "assertion_messages": 0 passes, 1 failure, 0 exceptions in 0ms.

--- a/tests/assertion_messages_tests.c
+++ b/tests/assertion_messages_tests.c
@@ -1,0 +1,20 @@
+#include <cgreen/cgreen.h>
+#include <cgreen/constraint.h>
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+
+#ifdef __cplusplus
+using namespace cgreen;
+#endif
+
+Describe(AssertionMessage);
+BeforeEach(AssertionMessage) {}
+AfterEach(AssertionMessage) {}
+
+
+char something[42];
+Ensure(AssertionMessage, for_comparing_content_with_negative_length) {
+    assert_that(47, is_equal_to_contents_of(something, -4));
+}

--- a/tests/failure_messages.c++.expected
+++ b/tests/failure_messages.c++.expected
@@ -5,5 +5,5 @@ failure_messages_tests.c: Exception: FailureMessage -> for_CGREEN_PER_TEST_TIMEO
 failure_messages_tests.c: Exception: FailureMessage -> for_time_out_in_only_one_second 
 	Test terminated unexpectedly, likely from a non-standard exception or Posix signal
 
-Completed "FailureMessage": 0 passes, 0 failures, 2 exceptions in 0ms.
-Completed "failure_messages": 0 passes, 0 failures, 2 exceptions in 0ms.
+Completed "FailureMessage": 1 pass, 0 failures, 2 exceptions in 0ms.
+Completed "failure_messages": 1 pass, 0 failures, 2 exceptions in 0ms.

--- a/tests/failure_messages.c.expected
+++ b/tests/failure_messages.c.expected
@@ -5,5 +5,5 @@ failure_messages_tests.c: Exception: FailureMessage -> for_CGREEN_PER_TEST_TIMEO
 failure_messages_tests.c: Exception: FailureMessage -> for_time_out_in_only_one_second 
 	Test terminated unexpectedly, likely from a non-standard exception or Posix signal
 
-Completed "FailureMessage": 0 passes, 0 failures, 2 exceptions in 0ms.
-Completed "failure_messages": 0 passes, 0 failures, 2 exceptions in 0ms.
+Completed "FailureMessage": 1 pass, 0 failures, 2 exceptions in 0ms.
+Completed "failure_messages": 1 pass, 0 failures, 2 exceptions in 0ms.

--- a/tests/failure_messages_tests.c
+++ b/tests/failure_messages_tests.c
@@ -18,6 +18,13 @@ Ensure(FailureMessage, for_time_out_in_only_one_second) {
 }
 
 Ensure(FailureMessage, for_CGREEN_PER_TEST_TIMEOUT) {
-    setenv("CGREEN_PER_TEST_TIMEOUT", "2", false);
-    sleep(10);
+    // Setting the environment variable here does not work
+    // It needs to be set before the runner forks
+    //    setenv("CGREEN_PER_TEST_TIMEOUT", "1", true);
+    // so we leave that to the test environment...
+
+    // And fail if there is no environment variable set
+    assert_that(getenv("CGREEN_PER_TEST_TIMEOUT"), is_not_equal_to(NULL));
+    sleep(2);
+    fail_test("This test should have been aborted within CGREEN_PER_TEST_TIMEOUT seconds and not get here.");
 }

--- a/tools/cgreen_runner_output_diff
+++ b/tools/cgreen_runner_output_diff
@@ -10,6 +10,8 @@ lib=$2
 name=$3
 expected=$4
 
+echo "Comparing output for $2 with CGREEN_PER_TEST_TIMEOUT= $CGREEN_PER_TEST_TIMEOUT"
+
 # Run runner on library store output and error
 ${runner_dir}/cgreen-runner ${lib} > ${name}.output 2> ${name}.error
 cat ${name}.error >> ${name}.output


### PR DESCRIPTION
Assertion messages is a new output comparing test.

Added a script to easily accept new output:

`tests/accept_output_of assertion_messages c`

will copy the current (hopefully inspected and correct) new output for the assertions_messages test to the tests directory with the correct name.

Also rewrite the CGREEN_PER_TEST_TIMEOUT tests to fail of there is no environment variable and if it was not interrupted as per the timeout.