### PR TITLE
Test context renaming and fixing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -68,7 +68,7 @@ unit: build
 	  $(OUTPUT_DIFF) $(call OUTPUT_DIFF_ARGUMENTS,mock) ; \
 	  $(OUTPUT_DIFF) $(call OUTPUT_DIFF_ARGUMENTS,constraint) s/Terminated:.+[0-9]+/Terminated/ ; \
 	  $(OUTPUT_DIFF) $(call OUTPUT_DIFF_ARGUMENTS,assertion) ; \
-	  CGREEN_PER_TEST_TIMEOUT=1 $(OUTPUT_DIFF) $(call OUTPUT_DIFF_ARGUMENTS,failure) ; \
+	  CGREEN_PER_TEST_TIMEOUT=2 $(OUTPUT_DIFF) $(call OUTPUT_DIFF_ARGUMENTS,failure) ; \
 	  cd ../.. ; \
 	done
 

--- a/Makefile
+++ b/Makefile
@@ -66,7 +66,7 @@ unit: build
 	  tools/cgreen-runner -c `find tests -name $(PREFIX)cgreen_tests$(SUFFIX)` ; \
 	  tools/cgreen-runner -c `find tools/tests -name $(PREFIX)cgreen_runner_tests$(SUFFIX)` ; \
 	  $(OUTPUT_DIFF) $(call OUTPUT_DIFF_ARGUMENTS,mock) ; \
-	  $(OUTPUT_DIFF) $(call OUTPUT_DIFF_ARGUMENTS,constraint) s/Terminated:.+[0-9]+/Terminated/ ; \
+	  $(OUTPUT_DIFF) $(call OUTPUT_DIFF_ARGUMENTS,constraint) s/Terminated:.+[0-9]+/Terminated/ s/Quit:.+[0-9]+/Quit/ ; \
 	  $(OUTPUT_DIFF) $(call OUTPUT_DIFF_ARGUMENTS,assertion) ; \
 	  CGREEN_PER_TEST_TIMEOUT=2 $(OUTPUT_DIFF) $(call OUTPUT_DIFF_ARGUMENTS,failure) ; \
 	  cd ../.. ; \

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -152,7 +152,7 @@ macro_add_test(
 )
 
 macro_add_test(NAME failure_messages
-    COMMAND env "CGREEN_PER_TEST_TIMEOUT=1" ${CMAKE_CURRENT_SOURCE_DIR}/../tools/cgreen_runner_output_diff
+    COMMAND env "CGREEN_PER_TEST_TIMEOUT=2" ${CMAKE_CURRENT_SOURCE_DIR}/../tools/cgreen_runner_output_diff
             # Run the runner in directory
             ${CMAKE_CURRENT_BINARY_DIR}/../tools
             # .. on library

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -134,6 +134,7 @@ macro_add_test(
             # ... but execute the following extra SED commands on the output before making the comparison
             ${IGNORE_SOURCE_PATH_REGEX}
             s/Terminated:.+[0-9]+/Terminated/
+            s/Quit:.+[0-9]+/Quit/
 )
 
 macro_add_test(

--- a/tests/constraint_messages.c++.expected
+++ b/tests/constraint_messages.c++.expected
@@ -1,4 +1,4 @@
-Running "constraint_messages" (35 tests)...
+Running "constraint_messages" (36 tests)...
 constraint_messages_tests.c: Failure: FailureMessage -> for_always_followed_by_expectation 
 	Mocked function [some_mock] already has an expectation that it will always be called a certain way; any expectations declared after an always expectation are invalid
 
@@ -138,11 +138,14 @@ constraint_messages_tests.c: Failure: FailureMessage -> if_exception_was_expecte
 	Expected [(void)5] to throw [std::string]
 
 constraint_messages_tests.c: Exception: FailureMessage -> increments_exception_count_when_terminating_via_SIGQUIT 
+	Test terminated with signal: Quit
+
+constraint_messages_tests.c: Exception: FailureMessage -> increments_exception_count_when_terminating_via_SIGTERM 
 	Test terminated with signal: Terminated
 
 constraint_messages_tests.c: Exception: FailureMessage -> increments_exception_count_when_throwing 
 	Test terminated unexpectedly, likely from a non-standard exception or Posix signal
 
-Completed "FailureMessage": 0 passes, 32 failures, 3 exceptions in 0ms.
-Completed "constraint_messages": 0 passes, 32 failures, 3 exceptions in 0ms.
+Completed "FailureMessage": 0 passes, 32 failures, 4 exceptions in 0ms.
+Completed "constraint_messages": 0 passes, 32 failures, 4 exceptions in 0ms.
 terminate called without an active exception

--- a/tests/constraint_messages.c++.expected
+++ b/tests/constraint_messages.c++.expected
@@ -1,151 +1,147 @@
-Running "constraint_messages" (36 tests)...
-constraint_messages_tests.c: Failure: FailureMessage -> for_always_followed_by_expectation 
+Running "constraint_messages" (35 tests)...
+constraint_messages_tests.c: Failure: ConstraintMessage -> for_always_followed_by_expectation 
 	Mocked function [some_mock] already has an expectation that it will always be called a certain way; any expectations declared after an always expectation are invalid
 
-constraint_messages_tests.c: Failure: FailureMessage -> for_assert_that 
+constraint_messages_tests.c: Failure: ConstraintMessage -> for_assert_that 
 	Expected [0 == 1] to [be true]
 
-constraint_messages_tests.c: Failure: FailureMessage -> for_begins_with_string 
+constraint_messages_tests.c: Failure: ConstraintMessage -> for_begins_with_string 
 	Expected [does_not_begin_with_fourty_five] to [begin with string] [fourty_five]
 		actual value:			["this string does not begin with fortyfive"]
 		expected to begin with:		["fourtyfive"]
 
-constraint_messages_tests.c: Failure: FailureMessage -> for_contains_string 
+constraint_messages_tests.c: Failure: ConstraintMessage -> for_contains_string 
 	Expected [not_containing_fourty_five] to [contain string] [fourty_five]
 		actual value:			["this text is thirtythree"]
 		expected to contain:		["fortyfive"]
 
-constraint_messages_tests.c: Failure: FailureMessage -> for_does_not_contain_string 
+constraint_messages_tests.c: Failure: ConstraintMessage -> for_does_not_contain_string 
 	Expected [contains_fourty_five] to [not contain string] [fourty_five]
 		actual value:			["this string is fourtyfive"]
 		expected to not contain:	["fourtyfive"]
 
-constraint_messages_tests.c: Failure: FailureMessage -> for_equal_to_double 
+constraint_messages_tests.c: Failure: ConstraintMessage -> for_equal_to_double 
 	Expected [0] to [equal double] [1] within [8] significant figures
 		actual value:	0.000000
 		expected value:	1.000000
 
-constraint_messages_tests.c: Failure: FailureMessage -> for_equal_to_double_negative 
+constraint_messages_tests.c: Failure: ConstraintMessage -> for_equal_to_double_negative 
 	Expected [-1] to [equal double] [-2] within [8] significant figures
 		actual value:	-1.000000
 		expected value:	-2.000000
 
-constraint_messages_tests.c: Exception: FailureMessage -> for_incorrect_assert_throws 
+constraint_messages_tests.c: Failure: ConstraintMessage -> for_exception_was_expected_but_nothing_thrown 
+	Expected [(void)5] to throw [std::string]
+
+constraint_messages_tests.c: Exception: ConstraintMessage -> for_incorrect_assert_throws 
 	an exception was thrown during test: [something else]
 
-constraint_messages_tests.c: Failure: FailureMessage -> for_is_equal_to 
+constraint_messages_tests.c: Failure: ConstraintMessage -> for_is_equal_to 
 	Expected [fourty_five] to [equal] [thirty_three]
 		actual value:			[45]
 		expected value:			[33]
 
-constraint_messages_tests.c: Failure: FailureMessage -> for_is_equal_to_contents_of 
+constraint_messages_tests.c: Failure: ConstraintMessage -> for_is_equal_to_contents_of 
 	Expected [thirty_three] to [equal contents of] [fourty_five]
 		at offset:			[9]
 
-constraint_messages_tests.c: Failure: FailureMessage -> for_is_equal_to_double 
+constraint_messages_tests.c: Failure: ConstraintMessage -> for_is_equal_to_double 
 	Expected [four_point_five] to [equal double] [three_point_three] within [8] significant figures
 		actual value:	4.500000
 		expected value:	3.300000
 
-constraint_messages_tests.c: Failure: FailureMessage -> for_is_equal_to_string 
+constraint_messages_tests.c: Failure: ConstraintMessage -> for_is_equal_to_string 
 	Expected [thirty_three] to [equal string] [fourty_five]
 		actual value:			["this string is thirtythree"]
 		expected to equal:		["this string is fortyfive"]
 
-constraint_messages_tests.c: Failure: FailureMessage -> for_is_greater_than 
+constraint_messages_tests.c: Failure: ConstraintMessage -> for_is_greater_than 
 	Expected [thirty_three] to [be greater than] [fourty_five]
 		actual value:			[33]
 		expected to be greater than:	[45]
 
-constraint_messages_tests.c: Failure: FailureMessage -> for_is_greater_than_double 
+constraint_messages_tests.c: Failure: ConstraintMessage -> for_is_greater_than_double 
 	Expected [three_point_three] to [be greater than double] [four_point_five] within [8] significant figures
 		actual value:	3.300000
 		expected value:	4.500000
 
-constraint_messages_tests.c: Failure: FailureMessage -> for_is_greater_than_double_with_accuracy 
+constraint_messages_tests.c: Failure: ConstraintMessage -> for_is_greater_than_double_with_accuracy 
 	Expected [1.0] to [be greater than double] [1.0 + 1.0e-3 + DBL_EPSILON] within [4] significant figures
 		actual value:	1.000000
 		expected value:	1.001000
 
-constraint_messages_tests.c: Failure: FailureMessage -> for_is_less_than 
+constraint_messages_tests.c: Failure: ConstraintMessage -> for_is_less_than 
 	Expected [fourty_five] to [be less than] [thirty_three]
 		actual value:			[45]
 		expected to be less than:	[33]
 
-constraint_messages_tests.c: Failure: FailureMessage -> for_is_less_than_double 
+constraint_messages_tests.c: Failure: ConstraintMessage -> for_is_less_than_double 
 	Expected [four_point_five] to [be less than double] [three_point_three] within [8] significant figures
 		actual value:	4.500000
 		expected value:	3.300000
 
-constraint_messages_tests.c: Failure: FailureMessage -> for_is_less_than_double_with_accuracy 
+constraint_messages_tests.c: Failure: ConstraintMessage -> for_is_less_than_double_with_accuracy 
 	Expected [1.0] to [be less than double] [1.0 - 1.0e-3 - DBL_EPSILON] within [4] significant figures
 		actual value:	1.000000
 		expected value:	0.999000
 
-constraint_messages_tests.c: Failure: FailureMessage -> for_is_non_null 
+constraint_messages_tests.c: Failure: ConstraintMessage -> for_is_non_null 
 	Expected [pointer] to [be non null]
 
-constraint_messages_tests.c: Failure: FailureMessage -> for_is_not_equal_to 
+constraint_messages_tests.c: Failure: ConstraintMessage -> for_is_not_equal_to 
 	Expected [should_not_be_fourty_five] to [not equal] [forty_five]
 		actual value:			[45]
 
-constraint_messages_tests.c: Failure: FailureMessage -> for_is_not_equal_to_contents_of 
+constraint_messages_tests.c: Failure: ConstraintMessage -> for_is_not_equal_to_contents_of 
 	Expected [fourty_five_and_up] to [not equal contents of] [another_fourty_five_and_up]
 
-constraint_messages_tests.c: Failure: FailureMessage -> for_is_not_equal_to_double 
+constraint_messages_tests.c: Failure: ConstraintMessage -> for_is_not_equal_to_double 
 	Expected [four_point_five] to [not equal double] [almost_four_point_five] within [4] significant figures
 		actual value:	4.500000
 		expected value:	4.499900
 
-constraint_messages_tests.c: Failure: FailureMessage -> for_is_not_equal_to_string 
+constraint_messages_tests.c: Failure: ConstraintMessage -> for_is_not_equal_to_string 
 	Expected [another_fourty_five] to [not equal string] [fourty_five]
 		actual value:			["this string is fourtyfive"]
 
-constraint_messages_tests.c: Failure: FailureMessage -> for_is_null 
+constraint_messages_tests.c: Failure: ConstraintMessage -> for_is_null 
 	Expected [pointer] to [be null]
 
-constraint_messages_tests.c: Failure: FailureMessage -> for_mock_called_more_times_than_expected 
+constraint_messages_tests.c: Failure: ConstraintMessage -> for_mock_called_more_times_than_expected 
 	Mocked function [some_mock] was called too many times
 
-constraint_messages_tests.c: Failure: FailureMessage -> for_mock_called_with_unexpected_parameter_value 
+constraint_messages_tests.c: Failure: ConstraintMessage -> for_mock_called_with_unexpected_parameter_value 
 	Expected [[parameter] parameter in [some_mock]] to [equal] [1]
 		actual value:			[0]
 		expected value:			[1]
 
-constraint_messages_tests.c: Failure: FailureMessage -> for_mock_called_without_expectation 
+constraint_messages_tests.c: Failure: ConstraintMessage -> for_mock_called_without_expectation 
 	Mocked function [some_mock] did not have an expectation that it would be called
 
-constraint_messages_tests.c: Failure: FailureMessage -> for_mock_parameter_name_not_matching_constraint_parameter_name 
+constraint_messages_tests.c: Failure: ConstraintMessage -> for_mock_parameter_name_not_matching_constraint_parameter_name 
 	Mocked function [some_mock] did not define a parameter named [PARAMETER]. Did you misspell it in the expectation or forget it in the mock's argument list?
 
-constraint_messages_tests.c: Failure: FailureMessage -> for_no_mock_parameters_with_parameter_constraint 
+constraint_messages_tests.c: Failure: ConstraintMessage -> for_no_mock_parameters_with_parameter_constraint 
 	Mocked function [forgot_to_pass_parameters_mock] did not define a parameter named [x]. Did you misspell it in the expectation or forget it in the mock's argument list?
 
-constraint_messages_tests.c: Failure: FailureMessage -> for_not_equal_to_double 
+constraint_messages_tests.c: Failure: ConstraintMessage -> for_not_equal_to_double 
 	Expected [0] to [not equal double] [0] within [8] significant figures
 		actual value:	0.000000
 		expected value:	0.000000
 
-constraint_messages_tests.c: Failure: FailureMessage -> for_not_equal_to_double_negative 
+constraint_messages_tests.c: Failure: ConstraintMessage -> for_not_equal_to_double_negative 
 	Expected [-1] to [not equal double] [-1] within [8] significant figures
 		actual value:	-1.000000
 		expected value:	-1.000000
 
-constraint_messages_tests.c: Failure: FailureMessage -> for_violated_never_expect 
+constraint_messages_tests.c: Failure: ConstraintMessage -> for_violated_never_expect 
 	Mocked function [some_mock] has an expectation that it will never be called, but it was
 
-constraint_messages_tests.c: Failure: FailureMessage -> if_exception_was_expected_but_nothing_thrown 
-	Expected [(void)5] to throw [std::string]
-
-constraint_messages_tests.c: Exception: FailureMessage -> increments_exception_count_when_terminating_via_SIGQUIT 
+constraint_messages_tests.c: Exception: ConstraintMessage -> increments_exception_count_when_terminating_via_SIGQUIT 
 	Test terminated with signal: Quit
 
-constraint_messages_tests.c: Exception: FailureMessage -> increments_exception_count_when_terminating_via_SIGTERM 
+constraint_messages_tests.c: Exception: ConstraintMessage -> increments_exception_count_when_terminating_via_SIGTERM 
 	Test terminated with signal: Terminated
 
-constraint_messages_tests.c: Exception: FailureMessage -> increments_exception_count_when_throwing 
-	Test terminated unexpectedly, likely from a non-standard exception or Posix signal
-
-Completed "FailureMessage": 0 passes, 32 failures, 4 exceptions in 0ms.
-Completed "constraint_messages": 0 passes, 32 failures, 4 exceptions in 0ms.
-terminate called without an active exception
+Completed "ConstraintMessage": 0 passes, 32 failures, 3 exceptions in 0ms.
+Completed "constraint_messages": 0 passes, 32 failures, 3 exceptions in 0ms.

--- a/tests/constraint_messages.c.expected
+++ b/tests/constraint_messages.c.expected
@@ -1,4 +1,4 @@
-Running "constraint_messages" (32 tests)...
+Running "constraint_messages" (33 tests)...
 constraint_messages_tests.c: Failure: FailureMessage -> for_always_followed_by_expectation 
 	Mocked function [some_mock] already has an expectation that it will always be called a certain way; any expectations declared after an always expectation are invalid
 
@@ -132,7 +132,10 @@ constraint_messages_tests.c: Failure: FailureMessage -> for_violated_never_expec
 	Mocked function [some_mock] has an expectation that it will never be called, but it was
 
 constraint_messages_tests.c: Exception: FailureMessage -> increments_exception_count_when_terminating_via_SIGQUIT 
+	Test terminated with signal: Quit
+
+constraint_messages_tests.c: Exception: FailureMessage -> increments_exception_count_when_terminating_via_SIGTERM 
 	Test terminated with signal: Terminated
 
-Completed "FailureMessage": 0 passes, 31 failures, 1 exception in 0ms.
-Completed "constraint_messages": 0 passes, 31 failures, 1 exception in 0ms.
+Completed "FailureMessage": 0 passes, 31 failures, 2 exceptions in 0ms.
+Completed "constraint_messages": 0 passes, 31 failures, 2 exceptions in 0ms.

--- a/tests/constraint_messages.c.expected
+++ b/tests/constraint_messages.c.expected
@@ -1,141 +1,141 @@
 Running "constraint_messages" (33 tests)...
-constraint_messages_tests.c: Failure: FailureMessage -> for_always_followed_by_expectation 
+constraint_messages_tests.c: Failure: ConstraintMessage -> for_always_followed_by_expectation 
 	Mocked function [some_mock] already has an expectation that it will always be called a certain way; any expectations declared after an always expectation are invalid
 
-constraint_messages_tests.c: Failure: FailureMessage -> for_assert_that 
+constraint_messages_tests.c: Failure: ConstraintMessage -> for_assert_that 
 	Expected [0 == 1] to [be true]
 
-constraint_messages_tests.c: Failure: FailureMessage -> for_begins_with_string 
+constraint_messages_tests.c: Failure: ConstraintMessage -> for_begins_with_string 
 	Expected [does_not_begin_with_fourty_five] to [begin with string] [fourty_five]
 		actual value:			["this string does not begin with fortyfive"]
 		expected to begin with:		["fourtyfive"]
 
-constraint_messages_tests.c: Failure: FailureMessage -> for_contains_string 
+constraint_messages_tests.c: Failure: ConstraintMessage -> for_contains_string 
 	Expected [not_containing_fourty_five] to [contain string] [fourty_five]
 		actual value:			["this text is thirtythree"]
 		expected to contain:		["fortyfive"]
 
-constraint_messages_tests.c: Failure: FailureMessage -> for_does_not_contain_string 
+constraint_messages_tests.c: Failure: ConstraintMessage -> for_does_not_contain_string 
 	Expected [contains_fourty_five] to [not contain string] [fourty_five]
 		actual value:			["this string is fourtyfive"]
 		expected to not contain:	["fourtyfive"]
 
-constraint_messages_tests.c: Failure: FailureMessage -> for_equal_to_double 
+constraint_messages_tests.c: Failure: ConstraintMessage -> for_equal_to_double 
 	Expected [0] to [equal double] [1] within [8] significant figures
 		actual value:	0.000000
 		expected value:	1.000000
 
-constraint_messages_tests.c: Failure: FailureMessage -> for_equal_to_double_negative 
+constraint_messages_tests.c: Failure: ConstraintMessage -> for_equal_to_double_negative 
 	Expected [-1] to [equal double] [-2] within [8] significant figures
 		actual value:	-1.000000
 		expected value:	-2.000000
 
-constraint_messages_tests.c: Failure: FailureMessage -> for_is_equal_to 
+constraint_messages_tests.c: Failure: ConstraintMessage -> for_is_equal_to 
 	Expected [fourty_five] to [equal] [thirty_three]
 		actual value:			[45]
 		expected value:			[33]
 
-constraint_messages_tests.c: Failure: FailureMessage -> for_is_equal_to_contents_of 
+constraint_messages_tests.c: Failure: ConstraintMessage -> for_is_equal_to_contents_of 
 	Expected [thirty_three] to [equal contents of] [fourty_five]
 		at offset:			[9]
 
-constraint_messages_tests.c: Failure: FailureMessage -> for_is_equal_to_double 
+constraint_messages_tests.c: Failure: ConstraintMessage -> for_is_equal_to_double 
 	Expected [four_point_five] to [equal double] [three_point_three] within [8] significant figures
 		actual value:	4.500000
 		expected value:	3.300000
 
-constraint_messages_tests.c: Failure: FailureMessage -> for_is_equal_to_string 
+constraint_messages_tests.c: Failure: ConstraintMessage -> for_is_equal_to_string 
 	Expected [thirty_three] to [equal string] [fourty_five]
 		actual value:			["this string is thirtythree"]
 		expected to equal:		["this string is fortyfive"]
 
-constraint_messages_tests.c: Failure: FailureMessage -> for_is_greater_than 
+constraint_messages_tests.c: Failure: ConstraintMessage -> for_is_greater_than 
 	Expected [thirty_three] to [be greater than] [fourty_five]
 		actual value:			[33]
 		expected to be greater than:	[45]
 
-constraint_messages_tests.c: Failure: FailureMessage -> for_is_greater_than_double 
+constraint_messages_tests.c: Failure: ConstraintMessage -> for_is_greater_than_double 
 	Expected [three_point_three] to [be greater than double] [four_point_five] within [8] significant figures
 		actual value:	3.300000
 		expected value:	4.500000
 
-constraint_messages_tests.c: Failure: FailureMessage -> for_is_greater_than_double_with_accuracy 
+constraint_messages_tests.c: Failure: ConstraintMessage -> for_is_greater_than_double_with_accuracy 
 	Expected [1.0] to [be greater than double] [1.0 + 1.0e-3 + DBL_EPSILON] within [4] significant figures
 		actual value:	1.000000
 		expected value:	1.001000
 
-constraint_messages_tests.c: Failure: FailureMessage -> for_is_less_than 
+constraint_messages_tests.c: Failure: ConstraintMessage -> for_is_less_than 
 	Expected [fourty_five] to [be less than] [thirty_three]
 		actual value:			[45]
 		expected to be less than:	[33]
 
-constraint_messages_tests.c: Failure: FailureMessage -> for_is_less_than_double 
+constraint_messages_tests.c: Failure: ConstraintMessage -> for_is_less_than_double 
 	Expected [four_point_five] to [be less than double] [three_point_three] within [8] significant figures
 		actual value:	4.500000
 		expected value:	3.300000
 
-constraint_messages_tests.c: Failure: FailureMessage -> for_is_less_than_double_with_accuracy 
+constraint_messages_tests.c: Failure: ConstraintMessage -> for_is_less_than_double_with_accuracy 
 	Expected [1.0] to [be less than double] [1.0 - 1.0e-3 - DBL_EPSILON] within [4] significant figures
 		actual value:	1.000000
 		expected value:	0.999000
 
-constraint_messages_tests.c: Failure: FailureMessage -> for_is_non_null 
+constraint_messages_tests.c: Failure: ConstraintMessage -> for_is_non_null 
 	Expected [pointer] to [be non null]
 
-constraint_messages_tests.c: Failure: FailureMessage -> for_is_not_equal_to 
+constraint_messages_tests.c: Failure: ConstraintMessage -> for_is_not_equal_to 
 	Expected [should_not_be_fourty_five] to [not equal] [forty_five]
 		actual value:			[45]
 
-constraint_messages_tests.c: Failure: FailureMessage -> for_is_not_equal_to_contents_of 
+constraint_messages_tests.c: Failure: ConstraintMessage -> for_is_not_equal_to_contents_of 
 	Expected [fourty_five_and_up] to [not equal contents of] [another_fourty_five_and_up]
 
-constraint_messages_tests.c: Failure: FailureMessage -> for_is_not_equal_to_double 
+constraint_messages_tests.c: Failure: ConstraintMessage -> for_is_not_equal_to_double 
 	Expected [four_point_five] to [not equal double] [almost_four_point_five] within [4] significant figures
 		actual value:	4.500000
 		expected value:	4.499900
 
-constraint_messages_tests.c: Failure: FailureMessage -> for_is_not_equal_to_string 
+constraint_messages_tests.c: Failure: ConstraintMessage -> for_is_not_equal_to_string 
 	Expected [another_fourty_five] to [not equal string] [fourty_five]
 		actual value:			["this string is fourtyfive"]
 
-constraint_messages_tests.c: Failure: FailureMessage -> for_is_null 
+constraint_messages_tests.c: Failure: ConstraintMessage -> for_is_null 
 	Expected [pointer] to [be null]
 
-constraint_messages_tests.c: Failure: FailureMessage -> for_mock_called_more_times_than_expected 
+constraint_messages_tests.c: Failure: ConstraintMessage -> for_mock_called_more_times_than_expected 
 	Mocked function [some_mock] was called too many times
 
-constraint_messages_tests.c: Failure: FailureMessage -> for_mock_called_with_unexpected_parameter_value 
+constraint_messages_tests.c: Failure: ConstraintMessage -> for_mock_called_with_unexpected_parameter_value 
 	Expected [[parameter] parameter in [some_mock]] to [equal] [1]
 		actual value:			[0]
 		expected value:			[1]
 
-constraint_messages_tests.c: Failure: FailureMessage -> for_mock_called_without_expectation 
+constraint_messages_tests.c: Failure: ConstraintMessage -> for_mock_called_without_expectation 
 	Mocked function [some_mock] did not have an expectation that it would be called
 
-constraint_messages_tests.c: Failure: FailureMessage -> for_mock_parameter_name_not_matching_constraint_parameter_name 
+constraint_messages_tests.c: Failure: ConstraintMessage -> for_mock_parameter_name_not_matching_constraint_parameter_name 
 	Mocked function [some_mock] did not define a parameter named [PARAMETER]. Did you misspell it in the expectation or forget it in the mock's argument list?
 
-constraint_messages_tests.c: Failure: FailureMessage -> for_no_mock_parameters_with_parameter_constraint 
+constraint_messages_tests.c: Failure: ConstraintMessage -> for_no_mock_parameters_with_parameter_constraint 
 	Mocked function [forgot_to_pass_parameters_mock] did not define a parameter named [x]. Did you misspell it in the expectation or forget it in the mock's argument list?
 
-constraint_messages_tests.c: Failure: FailureMessage -> for_not_equal_to_double 
+constraint_messages_tests.c: Failure: ConstraintMessage -> for_not_equal_to_double 
 	Expected [0] to [not equal double] [0] within [8] significant figures
 		actual value:	0.000000
 		expected value:	0.000000
 
-constraint_messages_tests.c: Failure: FailureMessage -> for_not_equal_to_double_negative 
+constraint_messages_tests.c: Failure: ConstraintMessage -> for_not_equal_to_double_negative 
 	Expected [-1] to [not equal double] [-1] within [8] significant figures
 		actual value:	-1.000000
 		expected value:	-1.000000
 
-constraint_messages_tests.c: Failure: FailureMessage -> for_violated_never_expect 
+constraint_messages_tests.c: Failure: ConstraintMessage -> for_violated_never_expect 
 	Mocked function [some_mock] has an expectation that it will never be called, but it was
 
-constraint_messages_tests.c: Exception: FailureMessage -> increments_exception_count_when_terminating_via_SIGQUIT 
+constraint_messages_tests.c: Exception: ConstraintMessage -> increments_exception_count_when_terminating_via_SIGQUIT 
 	Test terminated with signal: Quit
 
-constraint_messages_tests.c: Exception: FailureMessage -> increments_exception_count_when_terminating_via_SIGTERM 
+constraint_messages_tests.c: Exception: ConstraintMessage -> increments_exception_count_when_terminating_via_SIGTERM 
 	Test terminated with signal: Terminated
 
-Completed "FailureMessage": 0 passes, 31 failures, 2 exceptions in 0ms.
+Completed "ConstraintMessage": 0 passes, 31 failures, 2 exceptions in 0ms.
 Completed "constraint_messages": 0 passes, 31 failures, 2 exceptions in 0ms.

--- a/tests/constraint_messages_tests.c
+++ b/tests/constraint_messages_tests.c
@@ -179,6 +179,10 @@ Ensure(FailureMessage, for_no_mock_parameters_with_parameter_constraint) {
 }
 
 Ensure(FailureMessage, increments_exception_count_when_terminating_via_SIGQUIT) {
+    raise(SIGQUIT);
+}
+
+Ensure(FailureMessage, increments_exception_count_when_terminating_via_SIGTERM) {
     raise(SIGTERM);
 }
 

--- a/tests/constraint_messages_tests.c
+++ b/tests/constraint_messages_tests.c
@@ -11,125 +11,125 @@
 using namespace cgreen;
 #endif
 
-Describe(FailureMessage);
-BeforeEach(FailureMessage) {}
-AfterEach(FailureMessage) {}
+Describe(ConstraintMessage);
+BeforeEach(ConstraintMessage) {}
+AfterEach(ConstraintMessage) {}
 
-Ensure(FailureMessage,for_is_null) {
+Ensure(ConstraintMessage,for_is_null) {
     int i;
     int *pointer = &i;
     assert_that(pointer, is_null);
 }
 
-Ensure(FailureMessage,for_is_non_null) {
+Ensure(ConstraintMessage,for_is_non_null) {
     int *pointer = NULL;
     assert_that(pointer, is_non_null);
 }
 
-Ensure(FailureMessage,for_is_equal_to) {
+Ensure(ConstraintMessage,for_is_equal_to) {
     int fourty_five = 45, thirty_three = 33;
     assert_that(fourty_five, is_equal_to(thirty_three));
 }
 
-Ensure(FailureMessage,for_is_not_equal_to) {
+Ensure(ConstraintMessage,for_is_not_equal_to) {
     int should_not_be_fourty_five = 45, forty_five = 45;
     assert_that(should_not_be_fourty_five, is_not_equal_to(forty_five));
 }
 
-Ensure(FailureMessage,for_is_greater_than) {
+Ensure(ConstraintMessage,for_is_greater_than) {
     int fourty_five = 45, thirty_three = 33;
     assert_that(thirty_three, is_greater_than(fourty_five));
 }
 
-Ensure(FailureMessage,for_is_less_than) {
+Ensure(ConstraintMessage,for_is_less_than) {
     int fourty_five = 45, thirty_three = 33;
     assert_that(fourty_five, is_less_than(thirty_three));
 }
 
-Ensure(FailureMessage,for_is_equal_to_double) {
+Ensure(ConstraintMessage,for_is_equal_to_double) {
     double four_point_five = 4.5f, three_point_three = 3.3f;
     assert_that_double(four_point_five, is_equal_to_double(three_point_three));
 }
 
-Ensure(FailureMessage,for_is_not_equal_to_double) {
+Ensure(ConstraintMessage,for_is_not_equal_to_double) {
     significant_figures_for_assert_double_are(4);
     double epsilon = 1.0e-4;
     double four_point_five = 4.5, almost_four_point_five = 4.5 - epsilon;
     assert_that_double(four_point_five, is_not_equal_to_double(almost_four_point_five));
 }
 
-Ensure(FailureMessage,for_is_greater_than_double) {
+Ensure(ConstraintMessage,for_is_greater_than_double) {
     double four_point_five = 4.5f, three_point_three = 3.3f;
     assert_that_double(three_point_three, is_greater_than_double(four_point_five));
 }
 
-Ensure(FailureMessage,for_is_less_than_double) {
+Ensure(ConstraintMessage,for_is_less_than_double) {
     double four_point_five = 4.5f, three_point_three = 3.3f;
     assert_that_double(four_point_five, is_less_than_double(three_point_three));
 }
 
-Ensure(FailureMessage,for_is_equal_to_contents_of) {
+Ensure(ConstraintMessage,for_is_equal_to_contents_of) {
     int fourty_five[45] = {45, 44, 43}, thirty_three[33] = {45, 44, 33};
     assert_that(thirty_three, is_equal_to_contents_of(fourty_five, 55));
 }
 
-Ensure(FailureMessage,for_is_not_equal_to_contents_of) {
+Ensure(ConstraintMessage,for_is_not_equal_to_contents_of) {
     int fourty_five_and_up[3] = {45, 46, 47}, another_fourty_five_and_up[3] = {45, 46, 47};
     assert_that(fourty_five_and_up, is_not_equal_to_contents_of(another_fourty_five_and_up, 3));
 }
 
-Ensure(FailureMessage,for_is_equal_to_string) {
+Ensure(ConstraintMessage,for_is_equal_to_string) {
     const char *fourty_five = "this string is fortyfive", *thirty_three = "this string is thirtythree";
     assert_that(thirty_three, is_equal_to_string(fourty_five));
 }
 
-Ensure(FailureMessage,for_is_not_equal_to_string) {
+Ensure(ConstraintMessage,for_is_not_equal_to_string) {
     const char *fourty_five = "this string is fourtyfive", *another_fourty_five = "this string is fourtyfive";
     assert_that(another_fourty_five, is_not_equal_to_string(fourty_five));
 }
 
-Ensure(FailureMessage,for_contains_string) {
+Ensure(ConstraintMessage,for_contains_string) {
     const char *fourty_five = "fortyfive", *not_containing_fourty_five = "this text is thirtythree";
     assert_that(not_containing_fourty_five, contains_string(fourty_five));
 }
 
-Ensure(FailureMessage,for_does_not_contain_string) {
+Ensure(ConstraintMessage,for_does_not_contain_string) {
     const char *contains_fourty_five = "this string is fourtyfive", *fourty_five = "fourtyfive";
     assert_that(contains_fourty_five, does_not_contain_string(fourty_five));
 }
 
-Ensure(FailureMessage,for_begins_with_string) {
+Ensure(ConstraintMessage,for_begins_with_string) {
     const char *does_not_begin_with_fourty_five = "this string does not begin with fortyfive", *fourty_five = "fourtyfive";
     assert_that(does_not_begin_with_fourty_five, begins_with_string(fourty_five));
 }
 
-Ensure(FailureMessage,for_equal_to_double) {
+Ensure(ConstraintMessage,for_equal_to_double) {
   assert_that_double(0, is_equal_to_double(1));
 }
 
-Ensure(FailureMessage,for_equal_to_double_negative) {
+Ensure(ConstraintMessage,for_equal_to_double_negative) {
   assert_that_double(-1, is_equal_to_double(-2));
 }
 
-Ensure(FailureMessage,for_not_equal_to_double) {
+Ensure(ConstraintMessage,for_not_equal_to_double) {
   assert_that_double(0, is_not_equal_to_double(0));
 }
 
-Ensure(FailureMessage,for_not_equal_to_double_negative) {
+Ensure(ConstraintMessage,for_not_equal_to_double_negative) {
   assert_that_double(-1, is_not_equal_to_double(-1));
 }
 
-Ensure(FailureMessage,for_is_less_than_double_with_accuracy) {
+Ensure(ConstraintMessage,for_is_less_than_double_with_accuracy) {
   significant_figures_for_assert_double_are(4);
   assert_that_double(1.0, is_less_than_double(1.0 - 1.0e-3 - DBL_EPSILON));
 }
 
-Ensure(FailureMessage,for_is_greater_than_double_with_accuracy) {
+Ensure(ConstraintMessage,for_is_greater_than_double_with_accuracy) {
   significant_figures_for_assert_double_are(4);
   assert_that_double(1.0, is_greater_than_double(1.0 + 1.0e-3 + DBL_EPSILON));
 }
 
-Ensure(FailureMessage,for_assert_that) {
+Ensure(ConstraintMessage,for_assert_that) {
     assert_that(0 == 1);
 }
 
@@ -137,33 +137,33 @@ void some_mock(int parameter) {
     mock(parameter);
 }
 
-Ensure(FailureMessage, for_mock_called_without_expectation) {
+Ensure(ConstraintMessage, for_mock_called_without_expectation) {
     some_mock(0);
 }
 
-Ensure(FailureMessage, for_mock_called_more_times_than_expected) {
+Ensure(ConstraintMessage, for_mock_called_more_times_than_expected) {
     expect(some_mock);
     some_mock(0);
     some_mock(0);
 }
 
-Ensure(FailureMessage, for_mock_called_with_unexpected_parameter_value) {
+Ensure(ConstraintMessage, for_mock_called_with_unexpected_parameter_value) {
     expect(some_mock, when(parameter, is_equal_to(1)));
     some_mock(0);
 }
 
 /* And here are some tests that will fail with "illegal" type of messages */
-Ensure(FailureMessage, for_always_followed_by_expectation) {
+Ensure(ConstraintMessage, for_always_followed_by_expectation) {
     always_expect(some_mock, when(parameter, is_equal_to(1)));
     expect(some_mock, when(parameter, is_equal_to(0)));
 }
 
-Ensure(FailureMessage, for_violated_never_expect) {
+Ensure(ConstraintMessage, for_violated_never_expect) {
     never_expect(some_mock, when(parameter, is_equal_to(1)));
     some_mock(1);
 }
 
-Ensure(FailureMessage, for_mock_parameter_name_not_matching_constraint_parameter_name) {
+Ensure(ConstraintMessage, for_mock_parameter_name_not_matching_constraint_parameter_name) {
     expect(some_mock, when(PARAMETER, is_equal_to(0)));
     some_mock(0);
 }
@@ -173,29 +173,25 @@ void forgot_to_pass_parameters_mock(int x) {
     mock();
 }
 
-Ensure(FailureMessage, for_no_mock_parameters_with_parameter_constraint) {
+Ensure(ConstraintMessage, for_no_mock_parameters_with_parameter_constraint) {
     expect(forgot_to_pass_parameters_mock, when(x, is_equal_to(0)));
     forgot_to_pass_parameters_mock(0);
 }
 
-Ensure(FailureMessage, increments_exception_count_when_terminating_via_SIGQUIT) {
+Ensure(ConstraintMessage, increments_exception_count_when_terminating_via_SIGQUIT) {
     raise(SIGQUIT);
 }
 
-Ensure(FailureMessage, increments_exception_count_when_terminating_via_SIGTERM) {
+Ensure(ConstraintMessage, increments_exception_count_when_terminating_via_SIGTERM) {
     raise(SIGTERM);
 }
 
 #ifdef __cplusplus
-Ensure(FailureMessage, for_incorrect_assert_throws) {
+Ensure(ConstraintMessage, for_incorrect_assert_throws) {
     assert_throws(std::string, throw "something else");
 }
 
-Ensure(FailureMessage, if_exception_was_expected_but_nothing_thrown) {
+Ensure(ConstraintMessage, for_exception_was_expected_but_nothing_thrown) {
     assert_throws(std::string, (void)5);
-}
-
-Ensure(FailureMessage, increments_exception_count_when_throwing) {
-    throw;
 }
 #endif

--- a/tests/failure_messages.c++.expected
+++ b/tests/failure_messages.c++.expected
@@ -1,9 +1,13 @@
-Running "failure_messages" (2 tests)...
+Running "failure_messages" (3 tests)...
 failure_messages_tests.c: Exception: FailureMessage -> for_CGREEN_PER_TEST_TIMEOUT 
 	Test terminated unexpectedly, likely from a non-standard exception or Posix signal
 
 failure_messages_tests.c: Exception: FailureMessage -> for_time_out_in_only_one_second 
 	Test terminated unexpectedly, likely from a non-standard exception or Posix signal
 
-Completed "FailureMessage": 1 pass, 0 failures, 2 exceptions in 0ms.
-Completed "failure_messages": 1 pass, 0 failures, 2 exceptions in 0ms.
+failure_messages_tests.c: Exception: FailureMessage -> increments_exception_count_when_throwing 
+	Test terminated unexpectedly, likely from a non-standard exception or Posix signal
+
+Completed "FailureMessage": 1 pass, 0 failures, 3 exceptions in 0ms.
+Completed "failure_messages": 1 pass, 0 failures, 3 exceptions in 0ms.
+terminate called without an active exception

--- a/tests/failure_messages_tests.c
+++ b/tests/failure_messages_tests.c
@@ -20,11 +20,11 @@ Ensure(FailureMessage, for_time_out_in_only_one_second) {
 Ensure(FailureMessage, for_CGREEN_PER_TEST_TIMEOUT) {
     // Setting the environment variable here does not work
     // It needs to be set before the runner forks
-    //    setenv("CGREEN_PER_TEST_TIMEOUT", "1", true);
+    //    setenv("CGREEN_PER_TEST_TIMEOUT", "2", true);
     // so we leave that to the test environment...
 
     // And fail if there is no environment variable set
     assert_that(getenv("CGREEN_PER_TEST_TIMEOUT"), is_not_equal_to(NULL));
-    sleep(2);
+    sleep(3);
     fail_test("This test should have been aborted within CGREEN_PER_TEST_TIMEOUT seconds and not get here.");
 }

--- a/tests/failure_messages_tests.c
+++ b/tests/failure_messages_tests.c
@@ -28,3 +28,10 @@ Ensure(FailureMessage, for_CGREEN_PER_TEST_TIMEOUT) {
     sleep(3);
     fail_test("This test should have been aborted within CGREEN_PER_TEST_TIMEOUT seconds and not get here.");
 }
+
+#ifdef __cplusplus
+Ensure(FailureMessage, increments_exception_count_when_throwing) {
+    throw;
+}
+#endif
+


### PR DESCRIPTION
Context for constraints messages was called "Failures"... Also normalized the QUIT signal termination message before comparing to expected output