### PR TITLE
Add coverage target dependent on CGREEN_INTERNAL_WITH_GCOV setting

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -79,3 +79,22 @@ else()
     add_custom_target(check COMMAND ${CMAKE_CTEST_COMMAND} 
         --force-new-ctest-process --output-on-failure)
 endif()
+
+IF(CGREEN_WITH_CXX)
+  set(lang CXX)
+ELSE()
+  set(lang C)
+ENDIF()
+
+IF(CGREEN_INTERNAL_WITH_GCOV)
+  IF(CMAKE_${lang}_COMPILER_ID STREQUAL GNU)
+    add_custom_target(coverage
+        COMMAND ${LCOV_PATH} --directory . --capture --output-file coverage.info
+		COMMAND ${LCOV_PATH} --remove coverage.info '/usr/*' -o coverage.info
+		COMMAND ${GENHTML_PATH} -o coverage coverage.info
+    )
+  ENDIF()
+ELSE()
+  add_custom_target(coverage
+      COMMAND echo "WARNING: Configure CGREEN_INTERNAL_WITH_GCOV to get coverage")
+ENDIF()


### PR DESCRIPTION
Created a custom target `make coverage` which either creates coverge graphs using `lcov` and `genhtml` if enabled using CGREEN_INTERNAL_WITH_GCOV, which is an advanced CMake configuration option, or prints a message explaining that.