### PR TITLE
Unify reporter start and finish naming

### DIFF
--- a/doc/cgreen-guide-en.asciidoc
+++ b/doc/cgreen-guide-en.asciidoc
@@ -4,9 +4,10 @@
 :toc:
 :pp: ++
 
-= Cgreen - Unit Tests for C and C++
+= Cgreen - Unit Tests, Stubbing and Mocking for C and C++
 Marcus Baker <marcus@lastcraft.com>; Thomas Nilsson <thomas@junovagen.se>; João Freitas <joaohf@gmail.com>;
 
+Version: 1.0.0 beta 5
 
 Cgreen Quickstart Guide
 -----------------------
@@ -44,10 +45,10 @@ Here are some of its features:
 - Automatic discovery and running of tests using dynamic library inspection
 
 *Cgreen* also supports the classic xUnit-style assertions for easy
- porting from other frameworks.
+porting from other frameworks.
         
 *Cgreen* was initially developed to support C programming, but there
-is also excellent support for C++. It was initially a spinoff from a
+is also excellent support for C{pp}. It was initially a spinoff from a
 research project at Wordtracker and created by Marcus Baker.
 
 
@@ -65,9 +66,10 @@ made popular by people like Dan North and frameworks like JBehave,
 RSpec, Cucumber and Jasmine.
 
 *Cgreen* follows this trend and has evolved to embrace a BDD-flavoured
-style of testing. Although the fundamental mechanisms in TDD and BDD
-are much the same, the shift in focus by changing wording from 'tests'
-to 'behaviour specifications' is very significant.
+style of testing. Although the fundamental mechanisms in TDD and
+'technical' BDD are much the same, the shift in focus by changing
+wording from 'tests' to 'behaviour specifications' is very
+significant.
 
 This document will present *Cgreen* using the more modern and better
 BDD-style. In a later section you can have a peek at the classic TDD
@@ -81,26 +83,29 @@ There are two ways to install *Cgreen* in your system.
 Installing a package
 ^^^^^^^^^^^^^^^^^^^^
       
-The first way is to use the RPM or DEB package provided by the *Cgreen*
-Team. You can fetch it from http://cgreen.sourceforge.net[Cgreen
-website project]. Download and install it using the normal procedures
-for your system.
+The first way is to use the RPM or DEB package provided by the
+*Cgreen* Team. You can fetch it from
+https://github.com/cgreen-devs/cgreen/releases[Cgreen GitHub
+project]. Download and install it using the normal procedures for your
+system.
 
-NOTE: There is currently no supported packages available.
+NOTE: At this point there are no supported pre-built packages
+available. You'll have to build from source.
 
 Installing from source
 ^^^^^^^^^^^^^^^^^^^^^^
 
 The second way is available for developers and advanced
 users. Basically this consists of fetching the sources of the project
-on https://github.com/cgreen-devs/cgreen[GitHub] and compiling
-them. To do this you need the http://www.cmake.org[CMake] build
-system.
+on https://github.com/cgreen-devs/cgreen[GitHub], just click on
+"Download ZIP", and compiling them. To do this you need the
+http://www.cmake.org[CMake] build system.
 
 When you have the CMake tool, the steps are:
 
 -----------------------------------------
-$ tar -zxpvf cgreen.tar.gz
+$ unzip cgreen-master.zip
+$ cd cgreen-master
 $ make
 $ make test    
 $ make install
@@ -113,7 +118,7 @@ using *CMake*. This is called an 'out of source build'. It compiles
 file organization and enables multi-target builds from the same
 sources by leaving the complete source tree untouched. The top level
 `Makefile` will by default create the two directories, `build/build-c`
-and `build/build-c++`, which houses the __C__ and __C++__ builds
+and `build/build-c{pp}`, which houses the C and C++ builds
 respectively.
 
 TIP: Experienced users may tweak the build configurations by going to
@@ -123,7 +128,7 @@ subdirectory with a name starting with `build-` is also possible. The
 `Makefile` will automatically pick that up and build there too.
 
 The build process will create a library (on unix called `libcgreen.so`
-and `libcgreen++.so` for C++) which can be used in conjunction with the
+and `libcgreen{pp}.so` for C++) which can be used in conjunction with the
 `cgreen.h` header file to compile test code. The created library is
 installed in the system, by default in the `/usr/local/lib/`.
 
@@ -188,8 +193,9 @@ Let's add a meaningless test or two so that you can see how it runs...
 include::tutorial_src/first_tests1.c[]
 -----------------------------
 
-A test is denoted by the macro `Ensure`. You can think of a test as
-having a `void (void)` signature. You add the test to your suite using
+A test is denoted by the macro `Ensure` which takes an optional
+context (`Cgreen`) and a, hopefully descriptive, testname
+(`passes_this_test`). You add the test to your suite using
 `add_test_with_context()`.
 
 On compiling and running, we now get the output...
@@ -212,9 +218,9 @@ Five minutes doing TDD with Cgreen
 
 For a more realistic example we need something to test. We'll pretend
 that we are writing a function to split the words of a sentence in
-place. It does this by replacing any spaces with string terminators
-and returns the number of conversions plus one.  Here is an example of
-what we have in mind...
+place. It would do this by replacing any spaces with string
+terminators and returns the number of conversions plus one.  Here is
+an example of what we have in mind...
 
 [source,c]
 -------------------------------
@@ -331,8 +337,8 @@ The breadcrumb trail following the "Failure" text is the nesting of
 the tests. It goes from the test suites, which can be nested in each
 other, through the test function, and finally to the message from the
 assertion. In the language of *Cgreen*, a "failure" is a mismatched
-assertion, an "exception" occurs when a test fails to complete for any
-reason.
+assertion, or constraint, and an "exception" occurs when a test fails
+to complete for any reason, e.g. a segmentation fault.
 
 We could get this to pass just by returning the value 4. Doing TDD in
 really small steps, you would actually do this, but frankly this
@@ -718,7 +724,7 @@ Legacy style assertions
 Cgreen have been around for a while, developed and matured. There is
 an older style of assertions that was the initial version, a style
 that we now call the 'legacy style', because it was more aligned with
-the original, now old, unit test frameworks. If you are not interested
+the original, now older, unit test frameworks. If you are not interested
 in historical artifacts, I recommend that you skip this section.
 
 But for completeness of documentation, here are the legacy style
@@ -1111,10 +1117,10 @@ can only have one `Describe()` macro in each file. But using this
 strategy you can create composite suites that takes all your tests and
 run them in one go.
 
-CAUTION: Rewrite pending. The next couple section does not reflect the
-current best thinking. They are remnants of the TDD notation. Using
-BDD notation you would create separate contexts, each in its own file,
-with separate names, for each of the fixture cases.
+CAUTION: Rewrite pending. The next couple of sections does not reflect
+the current best thinking. They are remnants of the TDD
+notation. Using BDD notation you would create separate contexts, each
+in its own file, with separate names, for each of the fixture cases.
 
 NOTE: If you use the TDD (non-BDD) notation you can build several test
 suites in the same file, even nesting them.  We can even add mixtures
@@ -2225,7 +2231,7 @@ the name of the suite being entered and the number of tests in that
 suite. The default version keeps track of the stack of tests in the
 `breadcrumb` pointer of `TestReporter`. If you make use of the
 breadcrumb functions, as the defaults do, then you will need to call
-`reporter_start()` to keep the book keeping in sync.
+`reporter_start_suite()` to keep the book keeping in sync.
 
 
 `void (*start_test)(TestReporter *reporter, const char *name)`::
@@ -2234,7 +2240,7 @@ At the start of each test *Cgreen* will call this method on the
 reporter with the name of the test being entered. Again, the default
 version keeps track of the stack of tests in the `breadcrumb` pointer
 of `TestReporter`. If you make use of the breadcrumb functions, as the
-defaults do, then you will need to call `reporter_start()` to keep the
+defaults do, then you will need to call `reporter_start_test()` to keep the
 book keeping in sync.
 
 
@@ -2437,8 +2443,8 @@ navigating the test suite...
 include::tutorial_src/xml_reporter1.c[]
 -----------------------
 
-Although chaining to the underlying `reporter_start()`
-and `reporter_finish()` functions is optional, I want to
+Although chaining to the underlying `reporter_start_*()`
+and `reporter_finish_*()` functions is optional, I want to
 make use of some of the facilities later.
 
 Our output meanwhile, is making its first tentative steps...
@@ -2538,7 +2544,7 @@ and the error messages might not be straight forward to interpret.
 |*Compiler error message*                    |*Probable cause...*
 |`"contextFor<X>" is undeclared here`        |You forgot the `BeforeEach()` function
 |`undefined reference to 'AfterEach_For_<X>'`|You forgot the `AfterEach()` function
-|`CgreenSpec__<X>__<Y>__ is undeclared`      |You forgot to specify the test subject/context in a BDD style test
+|`CgreenSpec__<X>__<Y>__ is undeclared`      |You forgot to specify the test subject/context in the `Ensure` of a BDD style test
 |=========================================================
 
 

--- a/doc/tutorial_src/Makefile
+++ b/doc/tutorial_src/Makefile
@@ -4,15 +4,23 @@
 CGREEN_ROOT=../..
 FPIC = -fPIC	# required on Linux
 
-# Local tweaks, you can also override "MYSQL_*={somedir}" on the command line
-MYSQL_INCLUDE=
-MYSQL_LIB=
+# Local tweaks, you can also override "MYSQLROOT={somedir}" on the command line
+MYSQLROOT = 
+MYSQL_INCLUDE = $(MYSQLROOT)/include
+MYSQL_LIB = $(MYSQLROOT)/lib
 
 CGREEN_BIN=$(CGREEN_ROOT)/build/build-c
 CC = gcc -c -g -Wall -I$(CGREEN_ROOT)/include -I$(MYSQL_INCLUDE) -I$(FPIC)
 LINK = gcc -g
 LIBDIRS = -L$(CGREEN_BIN)/src -L$(MYSQL_LIB)
-RUNNER = PATH="$(CGREEN_BIN)/src:$(PATH)" $(CGREEN_BIN)/tools/cgreen-runner
+
+# you might need to fixup the various path issues to get dynamic loading to work
+# MacOSX:
+LDPATH = DYLD_LIBRARY_PATH="$(CGREEN_BIN)/src:$(MYSQL_LIB)"
+# Cygwin?
+#LDPATH = PATH="$(CGREEN_BIN)/src:$(MYSQL_LIB)"
+
+RUNNER = $(LDPATH) $(CGREEN_BIN)/tools/cgreen-runner
 
 all: with_main with_runner special
 
@@ -27,7 +35,7 @@ with_main:  first0 first1 \
 			test_as_xml2 \
 			test_as_xml3 \
 			test_as_xml4
-	for f in $^ ; do echo $$f; LD_LIBRARY_PATH=$(CGREEN_BIN)/src ./$$f | sed 's/[0-9]*\.c/.c/g' > $$f.out; done
+	for f in $^ ; do echo $$f; $(LDPATH) ./$$f | sed 's/[0-9]*\.c/.c/g' > $$f.out; done
 
 # Most tests built to run with the runner we can run here, but some need special care
 # They have their output produced directly in the build rules below

--- a/doc/tutorial_src/crash1.out
+++ b/doc/tutorial_src/crash1.out
@@ -1,5 +1,5 @@
 Running "main" (1 tests)...
 crash_tests.c:8: Exception: seg_faults_for_null_dereference 
-	Test terminated with signal: Segmentation fault
+	Test terminated with signal: Segmentation fault: 11
 
-Completed "main": 0 passes, 0 failures, 1 exception.
+Completed "main": 0 passes, 0 failures, 1 exception in 0ms.

--- a/doc/tutorial_src/crash3.out
+++ b/doc/tutorial_src/crash3.out
@@ -1,8 +1,8 @@
 Running "main" (2 tests)...
 crash_tests.c:8: Exception: seg_faults_for_null_dereference 
-	Test terminated with signal: Segmentation fault
+	Test terminated with signal: Segmentation fault: 11
 
 crash_tests.c:13: Exception: will_loop_forever 
 	Test terminated unexpectedly, likely from a non-standard exception or Posix signal
 
-Completed "main": 0 passes, 0 failures, 2 exceptions.
+Completed "main": 0 passes, 0 failures, 2 exceptions in 1002ms.

--- a/doc/tutorial_src/first0.out
+++ b/doc/tutorial_src/first0.out
@@ -1,2 +1,2 @@
 Running "main" (0 tests)...
-Completed "main": 0 passes, 0 failures, 0 exceptions.
+Completed "main": 0 passes, 0 failures, 0 exceptions in 0ms.

--- a/doc/tutorial_src/first1.out
+++ b/doc/tutorial_src/first1.out
@@ -2,4 +2,4 @@ Running "main" (2 tests)...
 first_tests.c:12: Failure: fails_this_test 
 	Expected [0 == 1] to [be true]
 
-Completed "main": 1 pass, 1 failure, 0 exceptions.
+Completed "main": 1 pass, 1 failure, 0 exceptions in 1ms.

--- a/doc/tutorial_src/formatter1.out
+++ b/doc/tutorial_src/formatter1.out
@@ -1,3 +1,3 @@
 Running "formatter" (1 tests)...
-Completed "Formatter": 1 pass, 0 failures, 0 exceptions.
-Completed "formatter": 1 pass, 0 failures, 0 exceptions.
+Completed "Formatter": 1 pass, 0 failures, 0 exceptions in 1ms.
+Completed "formatter": 1 pass, 0 failures, 0 exceptions in 1ms.

--- a/doc/tutorial_src/formatter2.out
+++ b/doc/tutorial_src/formatter2.out
@@ -1,3 +1,3 @@
 Running "formatter" (2 tests)...
-Completed "Formatter": 2 passes, 0 failures, 0 exceptions.
-Completed "formatter": 2 passes, 0 failures, 0 exceptions.
+Completed "Formatter": 2 passes, 0 failures, 0 exceptions in 1ms.
+Completed "formatter": 2 passes, 0 failures, 0 exceptions in 1ms.

--- a/doc/tutorial_src/formatter3.out
+++ b/doc/tutorial_src/formatter3.out
@@ -1,3 +1,3 @@
 Running "formatter" (3 tests)...
-Completed "Formatter": 5 passes, 0 failures, 0 exceptions.
-Completed "formatter": 5 passes, 0 failures, 0 exceptions.
+Completed "Formatter": 5 passes, 0 failures, 0 exceptions in 2ms.
+Completed "formatter": 5 passes, 0 failures, 0 exceptions in 2ms.

--- a/doc/tutorial_src/formatter4.out
+++ b/doc/tutorial_src/formatter4.out
@@ -1,3 +1,3 @@
 Running "formatter" (4 tests)...
-Completed "Formatter": 9 passes, 0 failures, 0 exceptions.
-Completed "formatter": 9 passes, 0 failures, 0 exceptions.
+Completed "Formatter": 9 passes, 0 failures, 0 exceptions in 3ms.
+Completed "formatter": 9 passes, 0 failures, 0 exceptions in 3ms.

--- a/doc/tutorial_src/formatter5.out
+++ b/doc/tutorial_src/formatter5.out
@@ -2,5 +2,5 @@ Running "formatter" (5 tests)...
 formatter_tests.c:59: Failure: Formatter -> ignores_empty_paragraphs 
 	Mocked function [writer] has an expectation that it will never be called, but it was
 
-Completed "Formatter": 9 passes, 1 failure, 0 exceptions.
-Completed "formatter": 9 passes, 1 failure, 0 exceptions.
+Completed "Formatter": 9 passes, 1 failure, 0 exceptions in 2ms.
+Completed "formatter": 9 passes, 1 failure, 0 exceptions in 2ms.

--- a/doc/tutorial_src/formatter6.out
+++ b/doc/tutorial_src/formatter6.out
@@ -1,3 +1,3 @@
 Running "formatter" (5 tests)...
-Completed "Formatter": 9 passes, 0 failures, 0 exceptions.
-Completed "formatter": 9 passes, 0 failures, 0 exceptions.
+Completed "Formatter": 9 passes, 0 failures, 0 exceptions in 2ms.
+Completed "formatter": 9 passes, 0 failures, 0 exceptions in 2ms.

--- a/doc/tutorial_src/multiple_streams1.out
+++ b/doc/tutorial_src/multiple_streams1.out
@@ -2,5 +2,5 @@ Running "multiple_streams" (1 tests)...
 multiple_streams.c:15: Failure: Streams -> bad_test 
 	Expected call was not made to mocked function [stream_stub]
 
-Completed "Streams": 0 passes, 1 failure, 0 exceptions.
-Completed "multiple_streams": 0 passes, 1 failure, 0 exceptions.
+Completed "Streams": 0 passes, 1 failure, 0 exceptions in 1ms.
+Completed "multiple_streams": 0 passes, 1 failure, 0 exceptions in 1ms.

--- a/doc/tutorial_src/multiple_streams2.out
+++ b/doc/tutorial_src/multiple_streams2.out
@@ -5,5 +5,5 @@ multiple_streams.c:19: Failure: Streams -> good_test
 multiple_streams.c:20: Failure: Streams -> good_test 
 	Expected call was not made to mocked function [second_stream_stub]
 
-Completed "Streams": 0 passes, 2 failures, 0 exceptions.
-Completed "multiple_streams": 0 passes, 2 failures, 0 exceptions.
+Completed "Streams": 0 passes, 2 failures, 0 exceptions in 0ms.
+Completed "multiple_streams": 0 passes, 2 failures, 0 exceptions in 0ms.

--- a/doc/tutorial_src/runner1.out
+++ b/doc/tutorial_src/runner1.out
@@ -2,5 +2,5 @@ Running "first_tests" (2 tests)...
 first_tests.c:12: Failure: Cgreen -> fails_this_test 
 	Expected [0 == 1] to [be true]
 
-Completed "Cgreen": 1 pass, 1 failure, 0 exceptions.
-Completed "first_tests": 1 pass, 1 failure, 0 exceptions.
+Completed "Cgreen": 1 pass, 1 failure, 0 exceptions in 1ms.
+Completed "first_tests": 1 pass, 1 failure, 0 exceptions in 1ms.

--- a/doc/tutorial_src/runner2.out
+++ b/doc/tutorial_src/runner2.out
@@ -2,5 +2,5 @@ Running "first_tests" (1 tests)...
 first_tests.c:12: Failure: Cgreen -> fails_this_test 
 	Expected [0 == 1] to [be true]
 
-Completed "Cgreen": 0 passes, 1 failure, 0 exceptions.
-Completed "first_tests": 0 passes, 1 failure, 0 exceptions.
+Completed "Cgreen": 0 passes, 1 failure, 0 exceptions in 0ms.
+Completed "first_tests": 0 passes, 1 failure, 0 exceptions in 0ms.

--- a/doc/tutorial_src/runner3.out
+++ b/doc/tutorial_src/runner3.out
@@ -6,5 +6,5 @@ Running "first_tests" (1 tests)...
 first_tests.c:12: Failure: Cgreen -> fails_this_test 
 	Expected [0 == 1] to [be true]
 
-Completed "Cgreen": 0 passes, 1 failure, 0 exceptions.
-Completed "first_tests": 0 passes, 1 failure, 0 exceptions.
+Completed "Cgreen": 0 passes, 1 failure, 0 exceptions in 0ms.
+Completed "first_tests": 0 passes, 1 failure, 0 exceptions in 0ms.

--- a/doc/tutorial_src/schema1.out
+++ b/doc/tutorial_src/schema1.out
@@ -7,4 +7,4 @@ schema_tests.c:30: Failure: can_add_person_to_database
 schema_tests.c:41: Failure: cannot_add_duplicate_person 
 	Expected [save_person(duplicate)] to [be false]
 
-Completed "person_tests": 1 pass, 2 failures, 0 exceptions.
+Completed "person_tests": 1 pass, 2 failures, 0 exceptions in 72ms.

--- a/doc/tutorial_src/schema2.out
+++ b/doc/tutorial_src/schema2.out
@@ -7,4 +7,4 @@ schema_tests.c:29: Failure: can_add_person_to_database
 schema_tests.c:38: Failure: cannot_add_duplicate_person 
 	Expected [save_person(duplicate)] to [be false]
 
-Completed "person_tests": 1 pass, 2 failures, 0 exceptions.
+Completed "person_tests": 1 pass, 2 failures, 0 exceptions in 20ms.

--- a/doc/tutorial_src/schema_tests1.c
+++ b/doc/tutorial_src/schema_tests1.c
@@ -1,6 +1,6 @@
 #include <cgreen/cgreen.h>
 #include <stdlib.h>
-#include <mysql/mysql.h>
+#include <mysql.h>
 #include "person.h"
 
 Describe(Person);

--- a/doc/tutorial_src/schema_tests2.c
+++ b/doc/tutorial_src/schema_tests2.c
@@ -1,6 +1,6 @@
 #include <cgreen/cgreen.h>
 #include <stdlib.h>
-#include <mysql/mysql.h>
+#include <mysql.h>
 #include "person.h"
 
 static void create_schema() {

--- a/doc/tutorial_src/stream0.out
+++ b/doc/tutorial_src/stream0.out
@@ -1,3 +1,3 @@
 Running "stream" (1 tests)...
-Completed "ParagraphReader": 1 pass, 0 failures, 0 exceptions.
-Completed "stream": 1 pass, 0 failures, 0 exceptions.
+Completed "ParagraphReader": 1 pass, 0 failures, 0 exceptions in 0ms.
+Completed "stream": 1 pass, 0 failures, 0 exceptions in 0ms.

--- a/doc/tutorial_src/stream1.out
+++ b/doc/tutorial_src/stream1.out
@@ -1,3 +1,3 @@
 Running "stream" (1 tests)...
-Completed "ParagraphReader": 1 pass, 0 failures, 0 exceptions.
-Completed "stream": 1 pass, 0 failures, 0 exceptions.
+Completed "ParagraphReader": 1 pass, 0 failures, 0 exceptions in 0ms.
+Completed "stream": 1 pass, 0 failures, 0 exceptions in 0ms.

--- a/doc/tutorial_src/stream2.out
+++ b/doc/tutorial_src/stream2.out
@@ -1,8 +1,8 @@
 Running "stream" (2 tests)...
 stream_tests.c:23: Failure: ParagraphReader -> gives_one_character_line_for_one_character_stream 
 	Expected [line] to [equal string] ["a"]
-		actual value:			["xa"]
+		actual value:			[""]
 		expected to equal:		["a"]
 
-Completed "ParagraphReader": 1 pass, 1 failure, 0 exceptions.
-Completed "stream": 1 pass, 1 failure, 0 exceptions.
+Completed "ParagraphReader": 1 pass, 1 failure, 0 exceptions in 1ms.
+Completed "stream": 1 pass, 1 failure, 0 exceptions in 1ms.

--- a/doc/tutorial_src/stream3.out
+++ b/doc/tutorial_src/stream3.out
@@ -1,3 +1,3 @@
 Running "stream" (2 tests)...
-Completed "ParagraphReader": 2 passes, 0 failures, 0 exceptions.
-Completed "stream": 2 passes, 0 failures, 0 exceptions.
+Completed "ParagraphReader": 2 passes, 0 failures, 0 exceptions in 1ms.
+Completed "stream": 2 passes, 0 failures, 0 exceptions in 1ms.

--- a/doc/tutorial_src/stream4.out
+++ b/doc/tutorial_src/stream4.out
@@ -1,3 +1,3 @@
 Running "stream" (3 tests)...
-Completed "ParagraphReader": 3 passes, 0 failures, 0 exceptions.
-Completed "stream": 3 passes, 0 failures, 0 exceptions.
+Completed "ParagraphReader": 3 passes, 0 failures, 0 exceptions in 2ms.
+Completed "stream": 3 passes, 0 failures, 0 exceptions in 2ms.

--- a/doc/tutorial_src/stream6.out
+++ b/doc/tutorial_src/stream6.out
@@ -1,3 +1,3 @@
 Running "stream" (5 tests)...
-Completed "ParagraphReader": 5 passes, 0 failures, 0 exceptions.
-Completed "stream": 5 passes, 0 failures, 0 exceptions.
+Completed "ParagraphReader": 5 passes, 0 failures, 0 exceptions in 2ms.
+Completed "stream": 5 passes, 0 failures, 0 exceptions in 2ms.

--- a/doc/tutorial_src/strlen1.out
+++ b/doc/tutorial_src/strlen1.out
@@ -1,2 +1,2 @@
 Running "our_tests" (1 tests)...
-Completed "our_tests": 1 pass, 0 failures, 0 exceptions.
+Completed "our_tests": 1 pass, 0 failures, 0 exceptions in 0ms.

--- a/doc/tutorial_src/strlen2.out
+++ b/doc/tutorial_src/strlen2.out
@@ -1,2 +1,2 @@
 Running "our_tests" (1 tests)...
-Completed "our_tests": 1 pass, 0 failures, 0 exceptions.
+Completed "our_tests": 1 pass, 0 failures, 0 exceptions in 1ms.

--- a/doc/tutorial_src/strlen3.out
+++ b/doc/tutorial_src/strlen3.out
@@ -1,2 +1,2 @@
 Running "our_tests" (1 tests)...
-Completed "our_tests": 1 pass, 0 failures, 0 exceptions.
+Completed "our_tests": 1 pass, 0 failures, 0 exceptions in 1ms.

--- a/doc/tutorial_src/strlen4.out
+++ b/doc/tutorial_src/strlen4.out
@@ -1,2 +1,2 @@
 Running "our_tests" (1 tests)...
-Completed "our_tests": 1 pass, 0 failures, 0 exceptions.
+Completed "our_tests": 1 pass, 0 failures, 0 exceptions in 1ms.

--- a/doc/tutorial_src/strlen5.out
+++ b/doc/tutorial_src/strlen5.out
@@ -1,2 +1,2 @@
 Running "our_tests" (1 tests)...
-Completed "our_tests": 1 pass, 0 failures, 0 exceptions.
+Completed "our_tests": 1 pass, 0 failures, 0 exceptions in 2ms.

--- a/doc/tutorial_src/strlen6.out
+++ b/doc/tutorial_src/strlen6.out
@@ -4,4 +4,4 @@ strlen_tests.c:9: Failure: returns_five_for_hello
 		actual value:			[4]
 		expected value:			[5]
 
-Completed "our_tests": 0 passes, 1 failure, 0 exceptions.
+Completed "our_tests": 0 passes, 1 failure, 0 exceptions in 4ms.

--- a/doc/tutorial_src/strlen7.out
+++ b/doc/tutorial_src/strlen7.out
@@ -4,4 +4,4 @@ strlen_tests.c:9: Failure: returns_five_for_hello
 		actual value:			[4]
 		expected value:			[5]
 
-Completed "our_tests": 1 pass, 1 failure, 0 exceptions.
+Completed "our_tests": 1 pass, 1 failure, 0 exceptions in 1ms.

--- a/doc/tutorial_src/suite1.out
+++ b/doc/tutorial_src/suite1.out
@@ -4,7 +4,7 @@ suite_strlen_tests.c:9: Failure: our_tests -> returns_five_for_hello
 		actual value:			[4]
 		expected value:			[5]
 
-Completed "our_tests": 1 pass, 1 failure, 0 exceptions.
+Completed "our_tests": 1 pass, 1 failure, 0 exceptions in 1ms.
 suite_person_tests.c:29: Failure: person_tests -> can_add_person_to_database 
 	Expected [get_person_name(found)] to [equal string] ["Fred"]
 		actual value:			["(null)"]
@@ -13,5 +13,5 @@ suite_person_tests.c:29: Failure: person_tests -> can_add_person_to_database
 suite_person_tests.c:38: Failure: person_tests -> cannot_add_duplicate_person 
 	Expected [save_person(duplicate)] to [be false]
 
-Completed "person_tests": 2 passes, 3 failures, 0 exceptions.
-Completed "main": 2 passes, 3 failures, 0 exceptions.
+Completed "person_tests": 2 passes, 3 failures, 0 exceptions in 23ms.
+Completed "main": 2 passes, 3 failures, 0 exceptions in 24ms.

--- a/doc/tutorial_src/suite_person_tests.c
+++ b/doc/tutorial_src/suite_person_tests.c
@@ -1,6 +1,6 @@
 #include <cgreen/cgreen.h>
 #include <stdlib.h>
-#include <mysql/mysql.h>
+#include <mysql.h>
 #include "person.h"
 
 static void create_schema() {

--- a/doc/tutorial_src/test_as_xml0.out
+++ b/doc/tutorial_src/test_as_xml0.out
@@ -2,5 +2,5 @@ Running "Top Level" (2 tests)...
 test_as_xml.c:12: Failure: A Group -> reports_a_test_that_fails 
 	A failure
 
-Completed "A Group": 1 pass, 1 failure, 0 exceptions.
-Completed "Top Level": 1 pass, 1 failure, 0 exceptions.
+Completed "A Group": 1 pass, 1 failure, 0 exceptions in 1ms.
+Completed "Top Level": 1 pass, 1 failure, 0 exceptions in 1ms.

--- a/doc/tutorial_src/test_as_xml2.out
+++ b/doc/tutorial_src/test_as_xml2.out
@@ -3,10 +3,6 @@
 <test name="reports_a_test_that_passes">
 </test>
 <test name="reports_a_test_that_fails">
-<fail>
-        <message>A failure</message>
-        <location file="test_as_xml.c" line="15"/>
-</fail>
 </test>
 </suite>
 </suite>

--- a/doc/tutorial_src/test_as_xml3.out
+++ b/doc/tutorial_src/test_as_xml3.out
@@ -3,10 +3,6 @@
 <test name="reports_a_test_that_passes">
 </test>
 <test name="reports_a_test_that_fails">
-<fail>
-        <message>A failure</message>
-        <location file="test_as_xml.c" line="15"/>
-</fail>
 </test>
 </suite>
 </suite>

--- a/doc/tutorial_src/test_as_xml4.out
+++ b/doc/tutorial_src/test_as_xml4.out
@@ -4,10 +4,6 @@
 		<test name="reports_a_test_that_passes">
 		</test>
 		<test name="reports_a_test_that_fails">
-			<fail>
-				<message>A failure</message>
-				<location file="test_as_xml.c" line="15"/>
-			</fail>
 		</test>
 	</suite>
 </suite>

--- a/doc/tutorial_src/words0.out
+++ b/doc/tutorial_src/words0.out
@@ -1,3 +1,3 @@
 Running "main" (0 tests)...
-Completed "words_tests": 0 passes, 0 failures, 0 exceptions.
-Completed "main": 0 passes, 0 failures, 0 exceptions.
+Completed "words_tests": 0 passes, 0 failures, 0 exceptions in 0ms.
+Completed "main": 0 passes, 0 failures, 0 exceptions in 0ms.

--- a/doc/tutorial_src/words1.out
+++ b/doc/tutorial_src/words1.out
@@ -4,5 +4,5 @@ words_tests.c:13: Failure: words_tests -> returns_word_count
 		actual value:			[0]
 		expected value:			[4]
 
-Completed "words_tests": 0 passes, 1 failure, 0 exceptions.
-Completed "main": 0 passes, 1 failure, 0 exceptions.
+Completed "words_tests": 0 passes, 1 failure, 0 exceptions in 1ms.
+Completed "main": 0 passes, 1 failure, 0 exceptions in 1ms.

--- a/doc/tutorial_src/words2.out
+++ b/doc/tutorial_src/words2.out
@@ -1,3 +1,3 @@
 Running "main" (1 tests)...
-Completed "words_tests": 1 pass, 0 failures, 0 exceptions.
-Completed "main": 1 pass, 0 failures, 0 exceptions.
+Completed "words_tests": 1 pass, 0 failures, 0 exceptions in 1ms.
+Completed "main": 1 pass, 0 failures, 0 exceptions in 1ms.

--- a/doc/tutorial_src/words3.out
+++ b/doc/tutorial_src/words3.out
@@ -4,5 +4,5 @@ words_tests.c:21: Failure: words_tests -> converts_spaces_to_zeroes
 		actual value:			[-32]
 		expected value:			[0]
 
-Completed "words_tests": 1 pass, 1 failure, 0 exceptions.
-Completed "main": 1 pass, 1 failure, 0 exceptions.
+Completed "words_tests": 1 pass, 1 failure, 0 exceptions in 1ms.
+Completed "main": 1 pass, 1 failure, 0 exceptions in 1ms.

--- a/doc/tutorial_src/words4.out
+++ b/doc/tutorial_src/words4.out
@@ -4,5 +4,5 @@ words_tests.c:13: Failure: words_tests -> returns_word_count
 		actual value:			[2]
 		expected value:			[4]
 
-Completed "words_tests": 1 pass, 1 failure, 0 exceptions.
-Completed "main": 1 pass, 1 failure, 0 exceptions.
+Completed "words_tests": 1 pass, 1 failure, 0 exceptions in 1ms.
+Completed "main": 1 pass, 1 failure, 0 exceptions in 1ms.

--- a/doc/tutorial_src/words5.out
+++ b/doc/tutorial_src/words5.out
@@ -1,3 +1,3 @@
 Running "main" (2 tests)...
-Completed "words_tests": 2 passes, 0 failures, 0 exceptions.
-Completed "main": 2 passes, 0 failures, 0 exceptions.
+Completed "words_tests": 2 passes, 0 failures, 0 exceptions in 1ms.
+Completed "main": 2 passes, 0 failures, 0 exceptions in 1ms.

--- a/doc/tutorial_src/words6.out
+++ b/doc/tutorial_src/words6.out
@@ -2,5 +2,5 @@ Running "main" (3 tests)...
 words_tests.c:33: Failure: words_tests -> invokes_callback_once_for_single_word_sentence 
 	Expected call was not made to mocked function [mocked_callback]
 
-Completed "words_tests": 2 passes, 1 failure, 0 exceptions.
-Completed "main": 2 passes, 1 failure, 0 exceptions.
+Completed "words_tests": 2 passes, 1 failure, 0 exceptions in 2ms.
+Completed "main": 2 passes, 1 failure, 0 exceptions in 2ms.

--- a/doc/tutorial_src/words7.out
+++ b/doc/tutorial_src/words7.out
@@ -1,3 +1,3 @@
 Running "main" (3 tests)...
-Completed "words_tests": 4 passes, 0 failures, 0 exceptions.
-Completed "main": 4 passes, 0 failures, 0 exceptions.
+Completed "words_tests": 4 passes, 0 failures, 0 exceptions in 2ms.
+Completed "main": 4 passes, 0 failures, 0 exceptions in 2ms.

--- a/doc/tutorial_src/words8.out
+++ b/doc/tutorial_src/words8.out
@@ -13,5 +13,5 @@ words_tests.c:40: Failure: words_tests -> invokes_callback_for_each_word_in_a_ph
 words_tests.c:41: Failure: words_tests -> invokes_callback_for_each_word_in_a_phrase 
 	Expected call was not made to mocked function [mocked_callback]
 
-Completed "words_tests": 4 passes, 4 failures, 0 exceptions.
-Completed "main": 4 passes, 4 failures, 0 exceptions.
+Completed "words_tests": 4 passes, 4 failures, 0 exceptions in 2ms.
+Completed "main": 4 passes, 4 failures, 0 exceptions in 2ms.

--- a/doc/tutorial_src/words9.out
+++ b/doc/tutorial_src/words9.out
@@ -1,3 +1,3 @@
 Running "main" (4 tests)...
-Completed "words_tests": 8 passes, 0 failures, 0 exceptions.
-Completed "main": 8 passes, 0 failures, 0 exceptions.
+Completed "words_tests": 8 passes, 0 failures, 0 exceptions in 2ms.
+Completed "main": 8 passes, 0 failures, 0 exceptions in 2ms.

--- a/doc/tutorial_src/xml_reporter.c
+++ b/doc/tutorial_src/xml_reporter.c
@@ -65,13 +65,13 @@ static void xml_show_incomplete(TestReporter *reporter, const char *name) {
 }
 
 static void xml_reporter_finish_test(TestReporter *reporter, const char *filename, int line) {
-    reporter_finish(reporter, filename, line);
+    reporter_finish_test(reporter, filename, line);
     indent(reporter);
     printf("</test>\n");
 }
 
 static void xml_reporter_finish_suite(TestReporter *reporter, const char *filename, int line) {
-    reporter_finish(reporter, filename, line);
+    reporter_finish_suite(reporter, filename, line);
     indent(reporter);
     printf("</suite>\n");
 }

--- a/doc/tutorial_src/xml_reporter1.c
+++ b/doc/tutorial_src/xml_reporter1.c
@@ -7,21 +7,21 @@
 
 static void xml_reporter_start_suite(TestReporter *reporter, const char *name, int count) {
     printf("<suite name=\"%s\">\n", name);
-    reporter_start(reporter, name);
+    reporter_start_suite(reporter, name, count);
 }
 
 static void xml_reporter_start_test(TestReporter *reporter, const char *name) {
     printf("<test name=\"%s\">\n", name);
-    reporter_start(reporter, name);
+    reporter_start_test(reporter, name);
 }
 
-static void xml_reporter_finish_test(TestReporter *reporter, const char *filename, int line, const char *message) {
-    reporter_finish(reporter, filename, line, message);
+static void xml_reporter_finish_test(TestReporter *reporter, const char *filename, int line, const char *message, uint32_t duration_in_milliseconds) {
+    reporter_finish_test(reporter, filename, line, message, duration_in_milliseconds);
     printf("</test>\n");
 }
 
-static void xml_reporter_finish_suite(TestReporter *reporter, const char *filename, int line) {
-    reporter_finish(reporter, filename, line, "");
+static void xml_reporter_finish_suite(TestReporter *reporter, const char *filename, int line, uint32_t duration_in_milliseconds) {
+    reporter_finish_suite(reporter, filename, line, duration_in_milliseconds);
     printf("</suite>\n");
 }
 

--- a/doc/tutorial_src/xml_reporter2.c
+++ b/doc/tutorial_src/xml_reporter2.c
@@ -8,12 +8,12 @@
 
 static void xml_reporter_start_suite(TestReporter *reporter, const char *name, int count) {
     printf("<suite name=\"%s\">\n", name);
-    reporter_start(reporter, name);
+    reporter_start_suite(reporter, name, count);
 }
 
 static void xml_reporter_start_test(TestReporter *reporter, const char *name) {
     printf("<test name=\"%s\">\n", name);
-    reporter_start(reporter, name);
+    reporter_start_test(reporter, name);
 }
 
 static void xml_show_fail(TestReporter *reporter, const char *file, int line, const char *message, va_list arguments) {
@@ -25,13 +25,13 @@ static void xml_show_fail(TestReporter *reporter, const char *file, int line, co
     printf("</fail>\n");
 }
 
-static void xml_reporter_finish_test(TestReporter *reporter, const char *filename, int line, const char *message) {
-    reporter_finish(reporter, filename, line, message);
+static void xml_reporter_finish_test(TestReporter *reporter, const char *filename, int line, const char *message, uint32_t duration_in_milliseconds) {
+    reporter_finish_test(reporter, filename, line, message, duration_in_milliseconds);
     printf("</test>\n");
 }
 
-static void xml_reporter_finish_suite(TestReporter *reporter, const char *filename, int line) {
-    reporter_finish(reporter, filename, line, "");
+static void xml_reporter_finish_suite(TestReporter *reporter, const char *filename, int line, uint32_t duration_in_milliseconds) {
+    reporter_finish_suite(reporter, filename, line, duration_in_milliseconds);
     printf("</suite>\n");
 }
 

--- a/doc/tutorial_src/xml_reporter3.c
+++ b/doc/tutorial_src/xml_reporter3.c
@@ -7,12 +7,12 @@
 
 static void xml_reporter_start_suite(TestReporter *reporter, const char *name, int count) {
     printf("<suite name=\"%s\">\n", name);
-    reporter_start(reporter, name);
+    reporter_start_suite(reporter, name, count);
 }
 
 static void xml_reporter_start_test(TestReporter *reporter, const char *name) {
     printf("<test name=\"%s\">\n", name);
-    reporter_start(reporter, name);
+    reporter_start_test(reporter, name);
 }
 
 static void xml_show_fail(TestReporter *reporter, const char *file, int line, const char *message, va_list arguments) {
@@ -31,13 +31,13 @@ static void xml_show_incomplete(TestReporter *reporter, const char *file, int li
 }
 
 
-static void xml_reporter_finish_test(TestReporter *reporter, const char *filename, int line, const char *message) {
-    reporter_finish(reporter, filename, line, message);
+static void xml_reporter_finish_test(TestReporter *reporter, const char *filename, int line, const char *message, uint32_t duration_in_milliseconds) {
+    reporter_finish_test(reporter, filename, line, message, duration_in_milliseconds);
     printf("</test>\n");
 }
 
-static void xml_reporter_finish_suite(TestReporter *reporter, const char *filename, int line) {
-    reporter_finish(reporter, filename, line, "");
+static void xml_reporter_finish_suite(TestReporter *reporter, const char *filename, int line, uint32_t duration_in_milliseconds) {
+    reporter_finish_suite(reporter, filename, line, duration_in_milliseconds);
     printf("</suite>\n");
 }
 

--- a/doc/tutorial_src/xml_reporter4.c
+++ b/doc/tutorial_src/xml_reporter4.c
@@ -17,13 +17,13 @@ static void xml_reporter_start_suite(TestReporter *reporter, const char *name, i
     }
     indent(reporter);
     printf("<suite name=\"%s\">\n", name);
-    reporter_start(reporter, name);
+    reporter_start_suite(reporter, name, count);
 }
 
 static void xml_reporter_start_test(TestReporter *reporter, const char *name) {
     indent(reporter);
     printf("<test name=\"%s\">\n", name);
-    reporter_start(reporter, name);
+    reporter_start_test(reporter, name);
 }
 
 static void xml_show_fail(TestReporter *reporter, const char *file, int line, const char *message, va_list arguments) {
@@ -49,14 +49,14 @@ static void xml_show_incomplete(TestReporter *reporter, const char *file, int li
 }
 
 
-static void xml_reporter_finish_test(TestReporter *reporter, const char *filename, int line, const char *message) {
-    reporter_finish(reporter, filename, line, message);
+static void xml_reporter_finish_test(TestReporter *reporter, const char *filename, int line, const char *message, uint32_t duration_in_milliseconds) {
+    reporter_finish_test(reporter, filename, line, message, duration_in_milliseconds);
     indent(reporter);
     printf("</test>\n");
 }
 
-static void xml_reporter_finish_suite(TestReporter *reporter, const char *filename, int line) {
-    reporter_finish(reporter, filename, line, "");
+static void xml_reporter_finish_suite(TestReporter *reporter, const char *filename, int line, uint32_t duration_in_milliseconds) {
+    reporter_finish_suite(reporter, filename, line, duration_in_milliseconds);
     indent(reporter);
     printf("</suite>\n");
 }

--- a/include/cgreen/reporter.h
+++ b/include/cgreen/reporter.h
@@ -39,9 +39,9 @@ void set_reporter_options(TestReporter *reporter, void *options);
 void setup_reporting(TestReporter *reporter);
 void destroy_reporter(TestReporter *reporter);
 void destroy_memo(TestReportMemo *memo);
-void reporter_start(TestReporter *reporter, const char *name);
+void reporter_start_test(TestReporter *reporter, const char *name);
 void reporter_start_suite(TestReporter *reporter, const char *name, const int count);
-void reporter_finish(TestReporter *reporter, const char *filename, int line, const char *message,
+void reporter_finish_test(TestReporter *reporter, const char *filename, int line, const char *message,
                      uint32_t duration_in_milliseconds);
 void reporter_finish_suite(TestReporter *reporter, const char *filename, int line, uint32_t duration_in_milliseconds);
 void add_reporter_result(TestReporter *reporter, int result);

--- a/src/cdash_reporter.c
+++ b/src/cdash_reporter.c
@@ -174,14 +174,14 @@ static void cdash_destroy_reporter(TestReporter *reporter) {
 static void cdash_reporter_start_suite(TestReporter *reporter, const char *name, const int number_of_tests) {
     (void)number_of_tests;
 
-    reporter_start(reporter, name);
+    reporter_start_test(reporter, name);
 }
 
 static void cdash_reporter_start_test(TestReporter *reporter, const char *name) {
     CDashMemo *memo = (CDashMemo *)reporter->memo;
 
     memo->teststarted = cdash_current_time(NULL);
-    reporter_start(reporter, name);
+    reporter_start_test(reporter, name);
 }
 
 
@@ -292,13 +292,13 @@ static void show_incomplete(TestReporter *reporter, const char *file, int line, 
 
 static void cdash_finish_test(TestReporter *reporter, const char *filename, int line,
                                              const char *message, uint32_t duration_in_milliseconds) {
-    reporter_finish(reporter, filename, line, message, duration_in_milliseconds);
+    reporter_finish_test(reporter, filename, line, message, duration_in_milliseconds);
 }
 
 
 static void cdash_finish_suite(TestReporter *reporter, const char *filename, int line,
                                           uint32_t duration_in_milliseconds) {
-    reporter_finish(reporter, filename, line, NULL, duration_in_milliseconds);
+    reporter_finish_test(reporter, filename, line, NULL, duration_in_milliseconds);
 }
 
 static time_t cdash_build_stamp(char *sbuildstamp, size_t sb) {

--- a/src/cute_reporter.c
+++ b/src/cute_reporter.c
@@ -15,7 +15,7 @@ typedef struct {
     int previous_error; // For status outside the test case process
 } CuteMemo;
 
-static void cute_suite_started(TestReporter *reporter,
+static void cute_start_suite(TestReporter *reporter,
         const char *name, const int number_of_tests);
 static void cute_start_test(TestReporter *reporter,
         const char *name);
@@ -52,7 +52,7 @@ TestReporter *create_cute_reporter(void) {
 
     memo->printer = printf;
 
-    reporter->start_suite = &cute_suite_started;
+    reporter->start_suite = &cute_start_suite;
     reporter->start_test = &cute_start_test;
     reporter->show_fail = &show_fail;
     reporter->show_pass = &show_pass;
@@ -64,7 +64,7 @@ TestReporter *create_cute_reporter(void) {
     return reporter;
 }
 
-static void cute_suite_started(TestReporter *reporter,
+static void cute_start_suite(TestReporter *reporter,
         const char *name, const int number_of_tests) {
     CuteMemo *memo = (CuteMemo *) reporter->memo;
     reporter_start_test(reporter, name);

--- a/src/cute_reporter.c
+++ b/src/cute_reporter.c
@@ -67,7 +67,7 @@ TestReporter *create_cute_reporter(void) {
 static void cute_suite_started(TestReporter *reporter,
         const char *name, const int number_of_tests) {
     CuteMemo *memo = (CuteMemo *) reporter->memo;
-    reporter_start(reporter, name);
+    reporter_start_test(reporter, name);
     memo->printer("#beginning %s %d\n", name, number_of_tests);
 }
 
@@ -76,7 +76,7 @@ static void cute_start_test(TestReporter *reporter,
     CuteMemo *memo = (CuteMemo *) reporter->memo;
     memo->error_count = reporter->failures + reporter->exceptions;
     memo->previous_error = 0;
-    reporter_start(reporter, name);
+    reporter_start_test(reporter, name);
     memo->printer("#starting %s\n", name);
 }
 
@@ -85,7 +85,7 @@ static void cute_finish_test(TestReporter *reporter, const char *filename, int l
     CuteMemo *memo = (CuteMemo *) reporter->memo;
     const char *name = get_current_from_breadcrumb((CgreenBreadcrumb *)reporter->breadcrumb);
 
-    reporter_finish(reporter, filename, line, message, duration_in_milliseconds);
+    reporter_finish_test(reporter, filename, line, message, duration_in_milliseconds);
     if (memo->error_count == reporter->failures + reporter->exceptions) {
         memo->printer("#success %s, %d ms OK\n", name);
     }
@@ -95,7 +95,7 @@ static void cute_finish_suite(TestReporter *reporter, const char *filename, int 
                                          uint32_t duration_in_milliseconds) {
     CuteMemo *memo = (CuteMemo *) reporter->memo;
     const char *name = get_current_from_breadcrumb((CgreenBreadcrumb *)reporter->breadcrumb);
-    reporter_finish(reporter, filename, line, NULL, duration_in_milliseconds);
+    reporter_finish_test(reporter, filename, line, NULL, duration_in_milliseconds);
 
     memo->printer("#ending %s", name);
     if (get_breadcrumb_depth((CgreenBreadcrumb *) reporter->breadcrumb) == 0) {

--- a/src/reporter.c
+++ b/src/reporter.c
@@ -59,12 +59,12 @@ TestReporter *create_reporter() {
 
     reporter->destroy = &destroy_reporter;
     reporter->start_suite = &reporter_start_suite;
-    reporter->start_test = &reporter_start;
+    reporter->start_test = &reporter_start_test;
     reporter->show_pass = &show_pass;
     reporter->show_fail = &show_fail;
     reporter->show_incomplete = &show_incomplete;
     reporter->assert_true = &assert_true;
-    reporter->finish_test = &reporter_finish;
+    reporter->finish_test = &reporter_finish_test;
     reporter->finish_suite = &reporter_finish_suite;
     reporter->passes = 0;
     reporter->failures = 0;
@@ -93,17 +93,17 @@ void destroy_memo(TestReportMemo *memo) {
     }
 }
 
-void reporter_start(TestReporter *reporter, const char *name) {
+void reporter_start_test(TestReporter *reporter, const char *name) {
     push_breadcrumb((CgreenBreadcrumb *) reporter->breadcrumb, name);
 }
 
 void reporter_start_suite(TestReporter *reporter, const char *name, const int count) {
     (void) count;
-    reporter_start(reporter, name);
+    push_breadcrumb((CgreenBreadcrumb *) reporter->breadcrumb, name);
 }
 
-void reporter_finish(TestReporter *reporter, const char *filename, int line, const char *message,
-                     uint32_t duration_in_milliseconds) {
+void reporter_finish_test(TestReporter *reporter, const char *filename, int line, const char *message,
+                          uint32_t duration_in_milliseconds) {
     (void)duration_in_milliseconds;
     int status = read_reporter_results(reporter);
 

--- a/src/text_reporter.c
+++ b/src/text_reporter.c
@@ -50,7 +50,7 @@ static bool have_quiet_mode(TestReporter *reporter) {
 
 static void text_reporter_start_suite(TestReporter *reporter, const char *name,
 		const int number_of_tests) {
-	reporter_start(reporter, name);
+	reporter_start_test(reporter, name);
 	if (get_breadcrumb_depth((CgreenBreadcrumb *) reporter->breadcrumb) == 1) {
 		printf("Running \"%s\" (%d tests)%s",
 				get_current_from_breadcrumb(
@@ -62,12 +62,12 @@ static void text_reporter_start_suite(TestReporter *reporter, const char *name,
 }
 
 static void text_reporter_start_test(TestReporter *reporter, const char *name) {
-	reporter_start(reporter, name);
+	reporter_start_test(reporter, name);
 }
 
 static void text_reporter_finish(TestReporter *reporter, const char *filename,
 		int line, const char *message, uint32_t duration_in_milliseconds) {
-	reporter_finish(reporter, filename, line, message, duration_in_milliseconds);
+	reporter_finish_test(reporter, filename, line, message, duration_in_milliseconds);
 }
 
 

--- a/tools/xml_reporter.c
+++ b/tools/xml_reporter.c
@@ -71,7 +71,7 @@ static void xml_reporter_start_suite(TestReporter *reporter, const char *suitena
     int segment_count = reporter->breadcrumb->depth;
     walk_breadcrumb(reporter->breadcrumb, pathprinter, &segment_count);
     fprintf(out, "%s\">\n", suitename);
-    reporter_start(reporter, suitename);
+    reporter_start_suite(reporter, suitename, 0);
 }
 
 static void xml_reporter_start_test(TestReporter *reporter, const char *testname) {
@@ -83,7 +83,7 @@ static void xml_reporter_start_test(TestReporter *reporter, const char *testname
 
     // Don't terminate the XML-node now so that we can add the duration later
     fprintf(out, "\" name=\"%s\"", testname);
-    reporter_start(reporter, testname);
+    reporter_start_test(reporter, testname);
 }
 
 static void xml_show_fail(TestReporter *reporter, const char *file, int line, const char *message, va_list arguments) {
@@ -117,7 +117,7 @@ static void xml_show_incomplete(TestReporter *reporter, const char *filename, in
 static void xml_reporter_finish_test(TestReporter *reporter, const char *filename, int line, const char *message,
                                      uint32_t duration_in_milliseconds) {
     FILE *out = file_stack[file_stack_p-1];
-    reporter_finish(reporter, filename, line, message, duration_in_milliseconds);
+    reporter_finish_test(reporter, filename, line, message, duration_in_milliseconds);
     fprintf(out, " time=\"%.5f\">\n", (double)duration_in_milliseconds/(double)1000);
     indent(out, reporter);
     fprintf(out, "</testcase>\n");


### PR DESCRIPTION
This PR renames the standard reporter functions for start and finish tests by adding `_test` to their names to make the naming more symmetric. Minor adjustments to the documentation and many tutorial source changes to make docs and code consistent.

This breaks the reporter API, which I think few people are using, but I'll hold merging this for a few days.

Maybe we should create a 1.0.0-beta5 tag before merging this and start making release notes aiming for a proper 1.0.0. I've drafted a first GitHub-release...