### PR TITLE
Fixes to make cgreen build on Win32 (MSVC VS2015)

### DIFF
--- a/include/cgreen/internal/windows_headers/wincompat.h
+++ b/include/cgreen/internal/windows_headers/wincompat.h
@@ -9,7 +9,9 @@
 
 typedef int pid_t;
 
-#define snprintf sprintf_s
+#if _MSC_VER < 1900
+   #define snprintf sprintf_s
+#endif
 
 #define sleep(x) Sleep(x*1000)
 #define mkdir(x,y) _mkdir(x)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -63,6 +63,7 @@ else(UNIX)
   if(WIN32)
     LIST(APPEND cgreen_SRCS 
       win32_cgreen_pipe.c
+      win32_cgreen_time.c
       win32_runner_platform.c
     )
   else(WIN32)

--- a/src/win32_cgreen_time.c
+++ b/src/win32_cgreen_time.c
@@ -1,0 +1,33 @@
+
+#include "cgreen/internal/cgreen_time.h"
+#include <stdint.h>
+#include <stdio.h>
+#include <unistd.h>
+#include <windows.h>
+
+#ifdef __cplusplus
+namespace cgreen {
+#endif
+
+   static LARGE_INTEGER qry_freq;
+   static bool qry_freq_initialized = false;
+
+   uint32_t cgreen_time_get_current_milliseconds() {
+      if (!qry_freq_initialized) {
+         QueryPerformanceFrequency(&qry_freq);
+         qry_freq_initialized = true;
+      }
+
+      LARGE_INTEGER current_count;
+      QueryPerformanceCounter(&current_count);
+
+      current_count.QuadPart = current_count.QuadPart * 1000000 / qry_freq.QuadPart;
+
+      return trunc(current_count.QuadPart / 1000);
+   }
+
+#ifdef __cplusplus
+} // namespace cgreen
+#endif
+
+  /* vim: set ts=4 sw=4 et cindent: */


### PR DESCRIPTION
These are the changes I had to make on the sourcecode to make a build in Visual Studio 2015.

I also had to disable some cmake settings and add the windows_headers path to the VS Project include directories, but I'm not entirely sure how to configure cmake to that extent.
