### PR TITLE
Add support for mocking functions by macro aliases

### DIFF
--- a/include/cgreen/assertions.h
+++ b/include/cgreen/assertions.h
@@ -2,6 +2,7 @@
 #define ASSERTIONS_HEADER
 
 #include "internal/assertions_internal.h"
+#include "internal/stringify_token.h"
 
 #include <cgreen/constraint.h>
 #include <cgreen/reporter.h>
@@ -26,7 +27,7 @@ namespace cgreen {
 
 */
 #define assert_that(...) assert_that_NARG(__VA_ARGS__)(__VA_ARGS__)
-#define assert_that_double(actual, constraint) assert_that_double_(__FILE__, __LINE__, #actual, (double)actual, constraint)
+#define assert_that_double(actual, constraint) assert_that_double_(__FILE__, __LINE__, STRINGIFY_TOKEN(actual), (double)actual, constraint)
 
 #define pass_test() assert_true(true)
 #define fail_test(...) assert_true_with_message(false, __VA_ARGS__)

--- a/include/cgreen/cpp_assertions.h
+++ b/include/cgreen/cpp_assertions.h
@@ -1,10 +1,13 @@
 #ifndef CGREEN_CPP_ASSERTIONS_H
 #define CGREEN_CPP_ASSERTIONS_H
 
+#include "internal/stringify_token.h"
+
 #define assert_throws(exceptionType, expr)                              \
     try {                                                               \
         expr;                                                           \
-        fail_test("Expected [" #expr "] to throw [" #exceptionType "]"); \
+        fail_test("Expected [" STRINGIFY_TOKEN(expr) "] "               \
+                "to throw [" STRINGIFY_TOKEN(exceptionType) "]");       \
     } catch (const exceptionType& ex) {                                 \
         pass_test();                                                    \
     } catch (const exceptionType* ex) {	                                \

--- a/include/cgreen/internal/CMakeLists.txt
+++ b/include/cgreen/internal/CMakeLists.txt
@@ -10,6 +10,7 @@ set(cgreen_internal_HDRS
   cgreen_time.h
   runner_platform.h
   function_macro.h
+  stringify_token.h
 )
 
 install(

--- a/include/cgreen/internal/assertions_internal.h
+++ b/include/cgreen/internal/assertions_internal.h
@@ -7,6 +7,7 @@
 #include "cpp_assertions.h"
 #endif
 #include "c_assertions.h"
+#include "stringify_token.h"
 
 
 #ifdef __cplusplus
@@ -32,7 +33,7 @@ namespace cgreen {
 #define assert_that_NARG(...) ASSERT_THAT_macro_dispatcher(assert_that, __VA_ARGS__)
 
 #define assert_that_expression(expression) \
-        assert_core_(__FILE__, __LINE__, #expression, expression, is_true);
+        assert_core_(__FILE__, __LINE__, STRINGIFY_TOKEN(expression), expression, is_true);
 
 void assert_equal_(const char *file, int line, const char *expression, intptr_t tried, intptr_t expected);
 void assert_not_equal_(const char *file, int line, const char *expression, intptr_t tried, intptr_t expected);

--- a/include/cgreen/internal/c_assertions.h
+++ b/include/cgreen/internal/c_assertions.h
@@ -4,8 +4,10 @@
 #include <cgreen/constraint.h>
 #include <inttypes.h>
 
+#include "stringify_token.h"
+
 #ifndef __cplusplus
-#define assert_that_constraint(actual, constraint) assert_core_(__FILE__, __LINE__, #actual, (intptr_t)actual, constraint)
+#define assert_that_constraint(actual, constraint) assert_core_(__FILE__, __LINE__, STRINGIFY_TOKEN(actual), (intptr_t)actual, constraint)
 #endif
 
 #ifdef __cplusplus

--- a/include/cgreen/internal/cpp_assertions.h
+++ b/include/cgreen/internal/cpp_assertions.h
@@ -6,9 +6,11 @@
 #include <string>
 #include <typeinfo>
 
+#include "stringify_token.h"
+
 namespace cgreen {
 
-    #define assert_that_constraint(actual, constraint) assert_that_(__FILE__, __LINE__, #actual, actual, constraint)
+    #define assert_that_constraint(actual, constraint) assert_that_(__FILE__, __LINE__, STRINGIFY_TOKEN(actual), actual, constraint)
 
 	void assert_that_(const char *file, int line, const char *actual_string, const std::string& actual, Constraint *constraint);
 	void assert_that_(const char *file, int line, const char *actual_string, const std::string *actual, Constraint *constraint);

--- a/include/cgreen/internal/stringify_token.h
+++ b/include/cgreen/internal/stringify_token.h
@@ -1,0 +1,7 @@
+#ifndef STRINGIFY_TOKEN_HEADER
+#define STRINGIFY_TOKEN_HEADER
+
+#define STRINGIFY_TOKEN(token) #token
+
+#endif
+

--- a/include/cgreen/internal/unit_implementation.h
+++ b/include/cgreen/internal/unit_implementation.h
@@ -5,6 +5,8 @@
 #include <cstddef>
 #endif
 
+#include "stringify_token.h"
+
 
 typedef struct {
     const char* name;
@@ -43,20 +45,20 @@ typedef struct {
 
 #define EnsureWithContextAndSpecificationName(skip, contextName, specName, ...) \
     static void contextName##__##specName (void);\
-    CgreenTest spec_name(contextName, specName) = { skip, &contextFor##contextName, #specName, &contextName##__##specName, __FILE__, __LINE__ }; \
+    CgreenTest spec_name(contextName, specName) = { skip, &contextFor##contextName, STRINGIFY_TOKEN(specName), &contextName##__##specName, __FILE__, __LINE__ }; \
     static void contextName##__##specName (void)
 
 extern CgreenContext defaultContext;
 
 #define EnsureWithSpecificationName(skip, specName, ...)   \
     static void specName (void);\
-    CgreenTest spec_name(default, specName) = { skip, &defaultContext, #specName, &specName, __FILE__, __LINE__ }; \
+    CgreenTest spec_name(default, specName) = { skip, &defaultContext, STRINGIFY_TOKEN(specName), &specName, __FILE__, __LINE__ }; \
     static void specName (void)
 
 #define DescribeImplementation(subject) \
         static void setup(void);                \
         static void teardown(void);                                     \
-        static CgreenContext contextFor##subject = { #subject, __FILE__, &setup, &teardown }; \
+        static CgreenContext contextFor##subject = { STRINGIFY_TOKEN(subject), __FILE__, &setup, &teardown }; \
         extern void(*BeforeEach_For_##subject)(void);                   \
         extern void(*AfterEach_For_##subject)(void);                    \
         static void setup(void) {                                       \

--- a/include/cgreen/legacy.h
+++ b/include/cgreen/legacy.h
@@ -1,24 +1,26 @@
 #ifndef LEGACY_HEADER
 #define LEGACY_HEADER
 
+#include "internal/stringify_token.h"
+
 
 /* Legacy style asserts:*/
 #define assert_true(result) \
-        (*get_test_reporter()->assert_true)(get_test_reporter(), __FILE__, __LINE__, result, "[" #result "] should be true\n", NULL)
+        (*get_test_reporter()->assert_true)(get_test_reporter(), __FILE__, __LINE__, result, "[" STRINGIFY_TOKEN(result) "] should be true\n", NULL)
 #define assert_false(result) \
-        (*get_test_reporter()->assert_true)(get_test_reporter(), __FILE__, __LINE__, ! result, "[" #result "] should be false\n", NULL)
+        (*get_test_reporter()->assert_true)(get_test_reporter(), __FILE__, __LINE__, ! result, "[" STRINGIFY_TOKEN(result) "] should be false\n", NULL)
 #define assert_equal(tried, expected) \
-        assert_equal_(__FILE__, __LINE__, #tried, (intptr_t)tried, (intptr_t)expected)
+        assert_equal_(__FILE__, __LINE__, STRINGIFY_TOKEN(tried), (intptr_t)tried, (intptr_t)expected)
 #define assert_not_equal(tried, expected) \
-        assert_not_equal_(__FILE__, __LINE__, #tried, (intptr_t)tried, (intptr_t)expected)
+        assert_not_equal_(__FILE__, __LINE__, STRINGIFY_TOKEN(tried), (intptr_t)tried, (intptr_t)expected)
 #define assert_double_equal(tried, expected) \
-        assert_double_equal_(__FILE__, __LINE__, #tried, tried, expected)
+        assert_double_equal_(__FILE__, __LINE__, STRINGIFY_TOKEN(tried), tried, expected)
 #define assert_double_not_equal(tried, expected) \
-        assert_double_not_equal_(__FILE__, __LINE__, #tried, tried, expected)
+        assert_double_not_equal_(__FILE__, __LINE__, STRINGIFY_TOKEN(tried), tried, expected)
 #define assert_string_equal(tried, expected) \
-        assert_string_equal_(__FILE__, __LINE__, #tried, tried, expected)
+        assert_string_equal_(__FILE__, __LINE__, STRINGIFY_TOKEN(tried), tried, expected)
 #define assert_string_not_equal(tried, expected) \
-        assert_string_not_equal_(__FILE__, __LINE__, #tried, tried, expected)
+        assert_string_not_equal_(__FILE__, __LINE__, STRINGIFY_TOKEN(tried), tried, expected)
 
 #define assert_true_with_message(result, ...) \
         (*get_test_reporter()->assert_true)(get_test_reporter(), __FILE__, __LINE__, result, __VA_ARGS__)

--- a/include/cgreen/mocks.h
+++ b/include/cgreen/mocks.h
@@ -2,6 +2,7 @@
 #define MOCKS_HEADER
 
 #include <cgreen/internal/mocks_internal.h>
+#include <cgreen/internal/stringify_token.h>
 #include <cgreen/constraint.h>
 #include <cgreen/reporter.h>
 
@@ -16,9 +17,9 @@ namespace cgreen {
 
    expect(<function>, when(<parameter>, <constraint>), will_return(<value>));
 */
-#define expect(f, ...) expect_(get_test_reporter(), #f, __FILE__, __LINE__, (Constraint *)__VA_ARGS__ +0, (Constraint *)0)
-#define always_expect(f, ...) always_expect_(get_test_reporter(), #f, __FILE__, __LINE__, (Constraint *)__VA_ARGS__ +0, (Constraint *)0)
-#define never_expect(f, ...) never_expect_(get_test_reporter(), #f, __FILE__, __LINE__, (Constraint *)__VA_ARGS__ +0, (Constraint *)0)
+#define expect(f, ...) expect_(get_test_reporter(), STRINGIFY_TOKEN(f), __FILE__, __LINE__, (Constraint *)__VA_ARGS__ +0, (Constraint *)0)
+#define always_expect(f, ...) always_expect_(get_test_reporter(), STRINGIFY_TOKEN(f), __FILE__, __LINE__, (Constraint *)__VA_ARGS__ +0, (Constraint *)0)
+#define never_expect(f, ...) never_expect_(get_test_reporter(), STRINGIFY_TOKEN(f), __FILE__, __LINE__, (Constraint *)__VA_ARGS__ +0, (Constraint *)0)
 
 
 #ifdef _MSC_VER

--- a/include/cgreen/suite.h
+++ b/include/cgreen/suite.h
@@ -18,10 +18,10 @@ namespace cgreen {
 
 #define create_test_suite() create_named_test_suite_(__func__, __FILE__, __LINE__)
 #define create_named_test_suite(name) create_named_test_suite_(name, __FILE__, __LINE__)
-#define add_test(suite, test) add_test_(suite, #test, &spec_name(default, test))
-#define add_test_with_context(suite, context, test) add_test_(suite, #test, &spec_name(context, test))
+#define add_test(suite, test) add_test_(suite, STRINGIFY_TOKEN(test), &spec_name(default, test))
+#define add_test_with_context(suite, context, test) add_test_(suite, STRINGIFY_TOKEN(test), &spec_name(context, test))
 #define add_tests(suite, ...) add_tests_(suite, #__VA_ARGS__, (CgreenTest *)__VA_ARGS__)
-#define add_suite(owner, suite) add_suite_(owner, #suite, suite)
+#define add_suite(owner, suite) add_suite_(owner, STRINGIFY_TOKEN(suite), suite)
 
 void set_setup(TestSuite *suite, void (*set_up)(void));
 void set_teardown(TestSuite *suite, void (*tear_down)(void));

--- a/tests/mocks_tests.c
+++ b/tests/mocks_tests.c
@@ -263,6 +263,28 @@ Ensure(Mocks, can_stub_an_out_parameter) {
     assert_that(&local, is_equal_to_contents_of(&actual, sizeof(LargerThanIntptr)));
 }
 
+// function which when mocked will be referred to by preprocessor macro
+static void function_macro_mock() {
+    mock();
+}
+
+#define FUNCTION_MACRO function_macro_mock
+
+Ensure(Mocks, can_mock_a_function_macro) {
+
+    // expect to mock by real function name
+    expect(function_macro_mock);
+
+    function_macro_mock();
+
+    // expect to mock by macro function name
+    expect(FUNCTION_MACRO);
+
+    FUNCTION_MACRO();
+}
+
+#undef FUNCTION_MACRO
+
 
 TestSuite *mock_tests() {
     TestSuite *suite = create_test_suite();


### PR DESCRIPTION
Previously any macro passed to an expectation had its token immediately
evaluated. This causes a problem since the resulting mocked function and
expectation token names would not match, resulting in failed tests such
as below:

```
Mocked function [real_function_symbol] did not have an expectation that
it would be called

Expected call was not made to mocked function [FUNCTION_SYMBOL_MACRO]
```

This was resolved by introducing a `STRINGIFY_TOKEN` macro which yields
the token string of the expanded macro, i.e. `real_function_symbol`
instead of `FUNCTION_SYMBOL_MACRO`.

Read more about [C Preprocessor Stringification](https://gcc.gnu.org/onlinedocs/cpp/Stringification.html)