### PR TITLE
percent signs in expected (#107)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -75,7 +75,6 @@ unit: build-it
 	$(OUTPUT_DIFF) $(call OUTPUT_DIFF_ARGUMENTS,assertion) ; \
 	$(OUTPUT_DIFF) $(call OUTPUT_DIFF_ARGUMENTS,ignore) ; \
 	CGREEN_PER_TEST_TIMEOUT=1 $(OUTPUT_DIFF) $(call OUTPUT_DIFF_ARGUMENTS,failure) ; \
-	cd ../../..
 
 .PHONY: doc
 doc: build

--- a/Makefile
+++ b/Makefile
@@ -67,14 +67,23 @@ unit: build-it
 	SOURCEDIR=$$PWD/tests/ ; \
 	cd build ; \
 	tools/cgreen-runner -c `find tests -name $(PREFIX)cgreen_c_tests$(SUFFIX)` ; \
+	r=$$((r + $$?)) ; \
 	tools/cgreen-runner -c `find tests -name $(PREFIX)cgreen_cpp_tests$(SUFFIX)` ; \
+	r=$$((r + $$?)) ; \
 	tools/cgreen-runner -c `find tools/tests -name $(PREFIX)cgreen_runner_tests$(SUFFIX)` ; \
+	r=$$((r + $$?)) ; \
 	cd tests ; \
 	$(OUTPUT_DIFF) $(call OUTPUT_DIFF_ARGUMENTS,mock) ; \
+	r=$$((r + $$?)) ; \
 	$(OUTPUT_DIFF) $(call OUTPUT_DIFF_ARGUMENTS,constraint) ; \
+	r=$$((r + $$?)) ; \
 	$(OUTPUT_DIFF) $(call OUTPUT_DIFF_ARGUMENTS,assertion) ; \
+	r=$$((r + $$?)) ; \
 	$(OUTPUT_DIFF) $(call OUTPUT_DIFF_ARGUMENTS,ignore) ; \
+	r=$$((r + $$?)) ; \
 	CGREEN_PER_TEST_TIMEOUT=1 $(OUTPUT_DIFF) $(call OUTPUT_DIFF_ARGUMENTS,failure) ; \
+	r=$$((r + $$?)) ; \
+	exit $$r
 
 .PHONY: doc
 doc: build

--- a/cmake/Modules/DefineCompilerFlags.cmake
+++ b/cmake/Modules/DefineCompilerFlags.cmake
@@ -12,7 +12,7 @@ if (UNIX)
     # add_compile_options(-Wall -Wextra -Wunused) # only since CMake 2.8.12, so...
     add_definitions(-Wall -Wextra -Wunused)
 
-    set(CMAKE_CXX_FLAGS "${CMAKE_C_FLAGS} -Weffc++")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++98 -Weffc++")
     set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -std=c99")
 
     if (CGREEN_INTERNAL_WITH_GCOV)

--- a/include/cgreen/assertions.h
+++ b/include/cgreen/assertions.h
@@ -2,6 +2,7 @@
 #define ASSERTIONS_HEADER
 
 #include "internal/assertions_internal.h"
+#include "internal/stringify_token.h"
 
 #include <cgreen/constraint.h>
 #include <cgreen/reporter.h>
@@ -26,7 +27,7 @@ namespace cgreen {
 
 */
 #define assert_that(...) assert_that_NARG(__VA_ARGS__)(__VA_ARGS__)
-#define assert_that_double(actual, constraint) assert_that_double_(__FILE__, __LINE__, #actual, (double)actual, constraint)
+#define assert_that_double(actual, constraint) assert_that_double_(__FILE__, __LINE__, STRINGIFY_TOKEN(actual), (double)actual, constraint)
 
 #define pass_test() assert_true(true)
 #define fail_test(...) assert_true_with_message(false, __VA_ARGS__)

--- a/include/cgreen/cpp_assertions.h
+++ b/include/cgreen/cpp_assertions.h
@@ -1,10 +1,13 @@
 #ifndef CGREEN_CPP_ASSERTIONS_H
 #define CGREEN_CPP_ASSERTIONS_H
 
+#include "internal/stringify_token.h"
+
 #define assert_throws(exceptionType, expr)                              \
     try {                                                               \
         expr;                                                           \
-        fail_test("Expected [" #expr "] to throw [" #exceptionType "]"); \
+        fail_test("Expected [" STRINGIFY_TOKEN(expr) "] "               \
+                "to throw [" STRINGIFY_TOKEN(exceptionType) "]");       \
     } catch (const exceptionType& ex) {                                 \
         pass_test();                                                    \
     } catch (const exceptionType* ex) {	                                \

--- a/include/cgreen/internal/CMakeLists.txt
+++ b/include/cgreen/internal/CMakeLists.txt
@@ -10,6 +10,7 @@ set(cgreen_internal_HDRS
   cgreen_time.h
   runner_platform.h
   function_macro.h
+  stringify_token.h
 )
 
 install(

--- a/include/cgreen/internal/assertions_internal.h
+++ b/include/cgreen/internal/assertions_internal.h
@@ -7,6 +7,7 @@
 #include "cpp_assertions.h"
 #endif
 #include "c_assertions.h"
+#include "stringify_token.h"
 
 
 #ifdef __cplusplus
@@ -32,7 +33,7 @@ namespace cgreen {
 #define assert_that_NARG(...) ASSERT_THAT_macro_dispatcher(assert_that, __VA_ARGS__)
 
 #define assert_that_expression(expression) \
-        assert_core_(__FILE__, __LINE__, #expression, expression, is_true);
+        assert_core_(__FILE__, __LINE__, STRINGIFY_TOKEN(expression), expression, is_true);
 
 void assert_equal_(const char *file, int line, const char *expression, intptr_t tried, intptr_t expected);
 void assert_not_equal_(const char *file, int line, const char *expression, intptr_t tried, intptr_t expected);

--- a/include/cgreen/internal/c_assertions.h
+++ b/include/cgreen/internal/c_assertions.h
@@ -4,8 +4,10 @@
 #include <cgreen/constraint.h>
 #include <inttypes.h>
 
+#include "stringify_token.h"
+
 #ifndef __cplusplus
-#define assert_that_constraint(actual, constraint) assert_core_(__FILE__, __LINE__, #actual, (intptr_t)actual, constraint)
+#define assert_that_constraint(actual, constraint) assert_core_(__FILE__, __LINE__, STRINGIFY_TOKEN(actual), (intptr_t)actual, constraint)
 #endif
 
 #ifdef __cplusplus

--- a/include/cgreen/internal/cpp_assertions.h
+++ b/include/cgreen/internal/cpp_assertions.h
@@ -6,9 +6,11 @@
 #include <string>
 #include <typeinfo>
 
+#include "stringify_token.h"
+
 namespace cgreen {
 
-    #define assert_that_constraint(actual, constraint) assert_that_(__FILE__, __LINE__, #actual, actual, constraint)
+    #define assert_that_constraint(actual, constraint) assert_that_(__FILE__, __LINE__, STRINGIFY_TOKEN(actual), actual, constraint)
 
 	void assert_that_(const char *file, int line, const char *actual_string, const std::string& actual, Constraint *constraint);
 	void assert_that_(const char *file, int line, const char *actual_string, const std::string *actual, Constraint *constraint);

--- a/include/cgreen/internal/stringify_token.h
+++ b/include/cgreen/internal/stringify_token.h
@@ -1,0 +1,7 @@
+#ifndef STRINGIFY_TOKEN_HEADER
+#define STRINGIFY_TOKEN_HEADER
+
+#define STRINGIFY_TOKEN(token) #token
+
+#endif
+

--- a/include/cgreen/internal/unit_implementation.h
+++ b/include/cgreen/internal/unit_implementation.h
@@ -5,6 +5,8 @@
 #include <cstddef>
 #endif
 
+#include "stringify_token.h"
+
 
 typedef struct {
     const char* name;
@@ -43,20 +45,20 @@ typedef struct {
 
 #define EnsureWithContextAndSpecificationName(skip, contextName, specName, ...) \
     static void contextName##__##specName (void);\
-    CgreenTest spec_name(contextName, specName) = { skip, &contextFor##contextName, #specName, &contextName##__##specName, __FILE__, __LINE__ }; \
+    CgreenTest spec_name(contextName, specName) = { skip, &contextFor##contextName, STRINGIFY_TOKEN(specName), &contextName##__##specName, __FILE__, __LINE__ }; \
     static void contextName##__##specName (void)
 
 extern CgreenContext defaultContext;
 
 #define EnsureWithSpecificationName(skip, specName, ...)   \
     static void specName (void);\
-    CgreenTest spec_name(default, specName) = { skip, &defaultContext, #specName, &specName, __FILE__, __LINE__ }; \
+    CgreenTest spec_name(default, specName) = { skip, &defaultContext, STRINGIFY_TOKEN(specName), &specName, __FILE__, __LINE__ }; \
     static void specName (void)
 
 #define DescribeImplementation(subject) \
         static void setup(void);                \
         static void teardown(void);                                     \
-        static CgreenContext contextFor##subject = { #subject, __FILE__, &setup, &teardown }; \
+        static CgreenContext contextFor##subject = { STRINGIFY_TOKEN(subject), __FILE__, &setup, &teardown }; \
         extern void(*BeforeEach_For_##subject)(void);                   \
         extern void(*AfterEach_For_##subject)(void);                    \
         static void setup(void) {                                       \

--- a/include/cgreen/legacy.h
+++ b/include/cgreen/legacy.h
@@ -1,24 +1,26 @@
 #ifndef LEGACY_HEADER
 #define LEGACY_HEADER
 
+#include "internal/stringify_token.h"
+
 
 /* Legacy style asserts:*/
 #define assert_true(result) \
-        (*get_test_reporter()->assert_true)(get_test_reporter(), __FILE__, __LINE__, result, "[" #result "] should be true\n", NULL)
+        (*get_test_reporter()->assert_true)(get_test_reporter(), __FILE__, __LINE__, result, "[" STRINGIFY_TOKEN(result) "] should be true\n", NULL)
 #define assert_false(result) \
-        (*get_test_reporter()->assert_true)(get_test_reporter(), __FILE__, __LINE__, ! result, "[" #result "] should be false\n", NULL)
+        (*get_test_reporter()->assert_true)(get_test_reporter(), __FILE__, __LINE__, ! result, "[" STRINGIFY_TOKEN(result) "] should be false\n", NULL)
 #define assert_equal(tried, expected) \
-        assert_equal_(__FILE__, __LINE__, #tried, (intptr_t)tried, (intptr_t)expected)
+        assert_equal_(__FILE__, __LINE__, STRINGIFY_TOKEN(tried), (intptr_t)tried, (intptr_t)expected)
 #define assert_not_equal(tried, expected) \
-        assert_not_equal_(__FILE__, __LINE__, #tried, (intptr_t)tried, (intptr_t)expected)
+        assert_not_equal_(__FILE__, __LINE__, STRINGIFY_TOKEN(tried), (intptr_t)tried, (intptr_t)expected)
 #define assert_double_equal(tried, expected) \
-        assert_double_equal_(__FILE__, __LINE__, #tried, tried, expected)
+        assert_double_equal_(__FILE__, __LINE__, STRINGIFY_TOKEN(tried), tried, expected)
 #define assert_double_not_equal(tried, expected) \
-        assert_double_not_equal_(__FILE__, __LINE__, #tried, tried, expected)
+        assert_double_not_equal_(__FILE__, __LINE__, STRINGIFY_TOKEN(tried), tried, expected)
 #define assert_string_equal(tried, expected) \
-        assert_string_equal_(__FILE__, __LINE__, #tried, tried, expected)
+        assert_string_equal_(__FILE__, __LINE__, STRINGIFY_TOKEN(tried), tried, expected)
 #define assert_string_not_equal(tried, expected) \
-        assert_string_not_equal_(__FILE__, __LINE__, #tried, tried, expected)
+        assert_string_not_equal_(__FILE__, __LINE__, STRINGIFY_TOKEN(tried), tried, expected)
 
 #define assert_true_with_message(result, ...) \
         (*get_test_reporter()->assert_true)(get_test_reporter(), __FILE__, __LINE__, result, __VA_ARGS__)

--- a/include/cgreen/mocks.h
+++ b/include/cgreen/mocks.h
@@ -2,6 +2,7 @@
 #define MOCKS_HEADER
 
 #include <cgreen/internal/mocks_internal.h>
+#include <cgreen/internal/stringify_token.h>
 #include <cgreen/constraint.h>
 #include <cgreen/reporter.h>
 
@@ -16,9 +17,9 @@ namespace cgreen {
 
    expect(<function>, when(<parameter>, <constraint>), will_return(<value>));
 */
-#define expect(f, ...) expect_(get_test_reporter(), #f, __FILE__, __LINE__, (Constraint *)__VA_ARGS__ +0, (Constraint *)0)
-#define always_expect(f, ...) always_expect_(get_test_reporter(), #f, __FILE__, __LINE__, (Constraint *)__VA_ARGS__ +0, (Constraint *)0)
-#define never_expect(f, ...) never_expect_(get_test_reporter(), #f, __FILE__, __LINE__, (Constraint *)__VA_ARGS__ +0, (Constraint *)0)
+#define expect(f, ...) expect_(get_test_reporter(), STRINGIFY_TOKEN(f), __FILE__, __LINE__, (Constraint *)__VA_ARGS__ +0, (Constraint *)0)
+#define always_expect(f, ...) always_expect_(get_test_reporter(), STRINGIFY_TOKEN(f), __FILE__, __LINE__, (Constraint *)__VA_ARGS__ +0, (Constraint *)0)
+#define never_expect(f, ...) never_expect_(get_test_reporter(), STRINGIFY_TOKEN(f), __FILE__, __LINE__, (Constraint *)__VA_ARGS__ +0, (Constraint *)0)
 
 
 #ifdef _MSC_VER

--- a/include/cgreen/suite.h
+++ b/include/cgreen/suite.h
@@ -18,10 +18,10 @@ namespace cgreen {
 
 #define create_test_suite() create_named_test_suite_(__func__, __FILE__, __LINE__)
 #define create_named_test_suite(name) create_named_test_suite_(name, __FILE__, __LINE__)
-#define add_test(suite, test) add_test_(suite, #test, &spec_name(default, test))
-#define add_test_with_context(suite, context, test) add_test_(suite, #test, &spec_name(context, test))
+#define add_test(suite, test) add_test_(suite, STRINGIFY_TOKEN(test), &spec_name(default, test))
+#define add_test_with_context(suite, context, test) add_test_(suite, STRINGIFY_TOKEN(test), &spec_name(context, test))
 #define add_tests(suite, ...) add_tests_(suite, #__VA_ARGS__, (CgreenTest *)__VA_ARGS__)
-#define add_suite(owner, suite) add_suite_(owner, #suite, suite)
+#define add_suite(owner, suite) add_suite_(owner, STRINGIFY_TOKEN(suite), suite)
 
 void set_setup(TestSuite *suite, void (*set_up)(void));
 void set_teardown(TestSuite *suite, void (*tear_down)(void));

--- a/src/assertions.c
+++ b/src/assertions.c
@@ -16,7 +16,8 @@ namespace cgreen {
 #endif
 
 
-void assert_core_(const char *file, int line, const char *actual_string, intptr_t actual, Constraint* constraint) {
+void assert_core_(const char *file, int line, const char *actual_string, intptr_t actual,
+                  Constraint* constraint) {
 
     char *failure_message;
     if (NULL != constraint && is_not_comparing(constraint)) {

--- a/src/message_formatting.c
+++ b/src/message_formatting.c
@@ -201,19 +201,22 @@ char *failure_message_for(Constraint *constraint, const char *actual_string, int
 
     message = (char *)malloc(message_size);
 
+    /* if the actual value expression contains '%' we want it to survive the final expansion with
+       arguments that happens in assert_true() */
     actual_value_as_string = double_all_percent_signs_in(actual_string);
 
+    /* expand the constraint with the actual value in string format... */
     snprintf(message, message_size - 1,
              constraint_as_string_format,
              actual_value_as_string,
              constraint->name);
 
-    
     if (no_expected_value_in(constraint)) {
         return message;
     } else
         strcat(message, " ");
 
+    /* expand the expected value string for all assertions that have one... */
     snprintf(message + strlen(message), message_size - strlen(message) - 1,
              expected_value_string_format,
              constraint->expected_value_name);
@@ -247,6 +250,7 @@ char *failure_message_for(Constraint *constraint, const char *actual_string, int
         return message;
     }
 
+    /* show difference for contents as a position */
     if (is_content_comparing(constraint)) {
         int difference_index = find_index_of_difference((char *)constraint->expected_value,
                                                         (char *)actual_value,
@@ -259,10 +263,12 @@ char *failure_message_for(Constraint *constraint, const char *actual_string, int
         return message;
     }
 
+    /* add the actual value */
     snprintf(message + strlen(message), message_size - strlen(message) - 1,
              constraint->actual_value_message,
              actual_value);
 
+    /* add the expected value */
     if (strstr(constraint->name, "not ") == NULL) {
         strcat(message, "\n");
         snprintf(message + strlen(message), message_size - strlen(message) - 1,

--- a/src/message_formatting.c
+++ b/src/message_formatting.c
@@ -21,6 +21,53 @@
 namespace cgreen {
 #endif
 
+// Handling of percent signs
+static const char *next_percent_sign(const char *s) {
+    return strchr(s, '%');
+}
+
+static size_t count_percent_signs(char const *s)
+{
+    size_t count = 0;
+    char const *p = next_percent_sign(s);
+    while (p != NULL) {
+        count++;
+        p = next_percent_sign(p+1);
+    }
+    return count;
+}
+
+
+static char *copy_while_doubling_percent_signs(char *string, char const *original)
+{
+    char *destination = string;
+    const char *source = original;
+    const char *next = next_percent_sign(source);
+    for (; next != NULL; next = next_percent_sign(next+1)) {
+        size_t len = next - source + 1;
+        memcpy(destination, source, len);
+        destination += len;
+        *destination++ = '%';
+        source = next+1;
+    }
+    strcpy(destination, source);
+
+    return string;
+}
+
+
+static char *double_all_percent_signs_in(const char *original)
+{
+    size_t percent_count = count_percent_signs(original);
+    char *new_string = (char *)malloc(strlen(original) + percent_count + 1);
+    if (new_string == NULL) {
+        return NULL;
+    }
+    copy_while_doubling_percent_signs(new_string, original);
+    return new_string;
+}
+
+
 static int find_index_of_difference(char *expected, char *actual, size_t size_to_compare) {
     char *expectedp = expected;
     char *actualp = actual;
@@ -82,17 +129,17 @@ char *validation_failure_message_for(Constraint *constraint, intptr_t actual) {
 //  }
 
     if (is_content_comparing(constraint)) {
-        const char *compared_to_name;
+        const char *as_string;
         if (constraint->parameter_name != NULL) {
-            compared_to_name = constraint->parameter_name;
+            as_string = constraint->parameter_name;
         } else {
-            compared_to_name = constraint->expected_value_name;
+            as_string = constraint->expected_value_name;
         }
 
         if ((long signed)constraint->size_of_expected_value <= 0) {
             snprintf(message + strlen(message), message_size - strlen(message) - 1,
                     name_has_incorrect_size_message,
-                    compared_to_name,
+                    as_string,
                     (long signed)constraint->size_of_expected_value);
 
             return message;
@@ -101,7 +148,7 @@ char *validation_failure_message_for(Constraint *constraint, intptr_t actual) {
         if ((void *)actual == NULL) {
             snprintf(message + strlen(message), message_size - strlen(message) - 1,
             		null_used_for_compare_message,
-                    compared_to_name);
+                    as_string);
 
                 return message;
         }
@@ -109,7 +156,7 @@ char *validation_failure_message_for(Constraint *constraint, intptr_t actual) {
         if ((void *)constraint->expected_value == NULL) {
             snprintf(message + strlen(message), message_size - strlen(message) - 1,
             		null_used_for_actual_message,
-                    compared_to_name);
+                    as_string);
 
                 return message;
         }
@@ -119,71 +166,22 @@ char *validation_failure_message_for(Constraint *constraint, intptr_t actual) {
 }
 
 
-static const char *next_percent_sign(const char *s) {
-    return strchr(s, '%');
-}
-
-size_t count_percent_signs(char const *s)
-{
-    size_t count = 0;
-    char const *p = next_percent_sign(s);
-    while (p != NULL) {
-        count++;
-        p = next_percent_sign(p+1);
-    }
-    return count;
-}
-
-
-char *copy_while_doubling_percent_signs(char *string, char const *original)
-{
-    char *destination = string;
-    const char *source = original;
-    const char *next = next_percent_sign(source);
-    for (; next != NULL; next = next_percent_sign(next+1)) {
-        size_t len = next - source + 1;
-        memcpy(destination, source, len);
-        destination += len;
-        *destination++ = '%';
-        source = next+1;
-    }
-    strcpy(destination, source);
-
-    return string;
-}
-
-
-void double_all_percent_signs_in(char **original)
-{
-    size_t percent_count = count_percent_signs(*original);
-    if (percent_count == 0) {
-        return;
-    }
-    char *new_string = (char *)malloc(strlen(*original) + percent_count + 1);
-    if (new_string == NULL) {
-        return;
-    }
-    copy_while_doubling_percent_signs(new_string, *original);
-    free(*original);
-    *original = new_string;
-}
-
-
 static bool is_not_equal_to_string_constraint(Constraint *constraint) {
     return strstr(constraint->name, "not ") != NULL && strstr(constraint->name, "equal ") != NULL;
 }
 
 
-char *failure_message_for(Constraint *constraint, const char *actual_string, intptr_t actual) {
-    char actual_value_string[32];
-    const char *actual_value_constraint_name = "Expected [%s] to [%s]";
-    const char *expected_value_name =  "[%s]";
-    const char *actual_value_as_string = "\n\t\tactual value:\t\t\t[\"%s\"]";
+char *failure_message_for(Constraint *constraint, const char *actual_string, intptr_t actual_value) {
+    char actual_int_value_string[32];
+    const char *constraint_as_string_format = "Expected [%s] to [%s]";
+    const char *expected_value_string_format =  "[%s]";
+    const char *actual_value_string_format = "\n\t\tactual value:\t\t\t[\"%s\"]";
     const char *at_offset = "\n\t\tat offset:\t\t\t[%d]";
+    const char *actual_value_as_string;
     char *message;
-    size_t message_size = strlen(actual_value_constraint_name) +
-    		strlen(expected_value_name) +
-    		strlen(actual_value_as_string) +
+    size_t message_size = strlen(constraint_as_string_format) +
+    		strlen(expected_value_string_format) +
+    		strlen(actual_value_string_format) +
     		strlen(at_offset) +
     		strlen(constraint->actual_value_message) +
     		strlen(constraint->expected_value_message) +
@@ -192,32 +190,35 @@ char *failure_message_for(Constraint *constraint, const char *actual_string, int
     		strlen(actual_string) +
     		512; // just in case
 
-    snprintf(actual_value_string, sizeof(actual_value_string) - 1, "%" PRIdPTR, actual);
+    snprintf(actual_int_value_string, sizeof(actual_int_value_string) - 1, "%" PRIdPTR, actual_value);
 
     if (values_are_strings_in(constraint)) {
     	message_size += strlen((char *)constraint->expected_value);
-    	if (actual != (intptr_t)NULL) {
-    		message_size += strlen((char *)actual);
+    	if (actual_value != (intptr_t)NULL) {
+    		message_size += strlen((char *)actual_value);
     	}
     }
 
     message = (char *)malloc(message_size);
 
-    snprintf(message, message_size - 1,
-    		actual_value_constraint_name,
-    		actual_string,
-            constraint->name);
+    actual_value_as_string = double_all_percent_signs_in(actual_string);
 
+    snprintf(message, message_size - 1,
+             constraint_as_string_format,
+             actual_value_as_string,
+             constraint->name);
+
+    
     if (no_expected_value_in(constraint)) {
         return message;
     } else
         strcat(message, " ");
 
     snprintf(message + strlen(message), message_size - strlen(message) - 1,
-             expected_value_name,
+             expected_value_string_format,
              constraint->expected_value_name);
 
-    if (actual_value_not_necessary_for(constraint, actual_string, actual_value_string)) {
+    if (actual_value_not_necessary_for(constraint, actual_string, actual_int_value_string)) {
         /* when the actual string and the actual value are the same, don't print both of them */
         /* also, don't print "0" for false and "1" for true */
         /* also, don't print expected/actual for contents constraints since that is useless */
@@ -227,8 +228,8 @@ char *failure_message_for(Constraint *constraint, const char *actual_string, int
     /* for string constraints, print out the strings encountered and not their pointer values */
     if (values_are_strings_in(constraint)) {
         snprintf(message + strlen(message), message_size - strlen(message) - 1,
-                 actual_value_as_string,
-                 (const char *)actual);
+                 actual_value_string_format,
+                 (const char *)actual_value);
         if (!is_not_equal_to_string_constraint(constraint)) {
             strcat(message, "\n");
             snprintf(message + strlen(message), message_size - strlen(message) - 1,
@@ -238,13 +239,18 @@ char *failure_message_for(Constraint *constraint, const char *actual_string, int
         /* The final string may have percent characters, so, since it is
            later used in a (v)printf, we have to double them
         */
-        double_all_percent_signs_in(&message);
+        if (next_percent_sign(message) != NULL) {
+            char *message_with_doubled_percent_signs = double_all_percent_signs_in(message);
+            free(message);
+            message = message_with_doubled_percent_signs;
+        }
         return message;
     }
 
     if (is_content_comparing(constraint)) {
         int difference_index = find_index_of_difference((char *)constraint->expected_value,
-                                                        (char *)actual, constraint->size_of_expected_value);
+                                                        (char *)actual_value,
+                                                        constraint->size_of_expected_value);
         if (difference_index != -1) {
             snprintf(message + strlen(message), message_size - strlen(message) - 1,
                      at_offset,
@@ -255,7 +261,7 @@ char *failure_message_for(Constraint *constraint, const char *actual_string, int
 
     snprintf(message + strlen(message), message_size - strlen(message) - 1,
              constraint->actual_value_message,
-             actual);
+             actual_value);
 
     if (strstr(constraint->name, "not ") == NULL) {
         strcat(message, "\n");

--- a/src/text_reporter.c
+++ b/src/text_reporter.c
@@ -193,7 +193,7 @@ static void show_fail(TestReporter *reporter, const char *file, int line,
     } else {
         vsprintf(buffer, message, arguments);
     }
-    memo->printer(buffer);
+    memo->printer("%s", buffer);
     memo->printer("\n");
     memo->printer("\n");
     fflush(NULL);

--- a/tests/assertion_messages_tests.c
+++ b/tests/assertion_messages_tests.c
@@ -33,3 +33,7 @@ Ensure(AssertionMessage, for_compare_null_to_area) {
     char area[100];
     assert_that(NULL, is_equal_to_contents_of(area, 1));
 }
+
+Ensure(AssertionMessage, for_actual_with_percent) {
+    assert_that(strlen("%d"), is_equal_to(3)); /* Actually, it's not but should preserve '%' */
+}

--- a/tests/assertion_messages_tests.expected
+++ b/tests/assertion_messages_tests.expected
@@ -1,4 +1,9 @@
-Running "assertion_messages_tests" (4 tests)...
+Running "assertion_messages_tests" (5 tests)...
+assertion_messages_tests.c: Failure: AssertionMessage -> for_actual_with_percent 
+	Expected [strlen("%d")] to [equal] [3]
+		actual value:			[2]
+		expected value:			[3]
+
 assertion_messages_tests.c: Failure: AssertionMessage -> for_compare_area_to_null 
 	Wanted to compare contents of [null_pointer] but it had a value of NULL.
 		If you want to explicitly check for null, use the is_null constraint instead.
@@ -16,5 +21,5 @@ assertion_messages_tests.c: Failure: AssertionMessage -> return_value_constraint
 	Got constraint of type [return value],
 		but they are not allowed for assertions, only in mock expectations.
 
-Completed "AssertionMessage": 4 failures in 0ms.
-Completed "assertion_messages_tests": 4 failures in 0ms.
+Completed "AssertionMessage": 5 failures in 0ms.
+Completed "assertion_messages_tests": 5 failures in 0ms.

--- a/tests/mocks_tests.c
+++ b/tests/mocks_tests.c
@@ -263,6 +263,28 @@ Ensure(Mocks, can_stub_an_out_parameter) {
     assert_that(&local, is_equal_to_contents_of(&actual, sizeof(LargerThanIntptr)));
 }
 
+// function which when mocked will be referred to by preprocessor macro
+static void function_macro_mock() {
+    mock();
+}
+
+#define FUNCTION_MACRO function_macro_mock
+
+Ensure(Mocks, can_mock_a_function_macro) {
+
+    // expect to mock by real function name
+    expect(function_macro_mock);
+
+    function_macro_mock();
+
+    // expect to mock by macro function name
+    expect(FUNCTION_MACRO);
+
+    FUNCTION_MACRO();
+}
+
+#undef FUNCTION_MACRO
+
 
 TestSuite *mock_tests() {
     TestSuite *suite = create_test_suite();


### PR DESCRIPTION
#107 reports a problem where the string representation of the actual value contains '%'.

This PR fixes that problem.

- printer of text_reporter mapped directly to `printf(string)`, i.e. using the input string as a format string.
- handling of the actuals string representation did not quote percent signs