### PR TITLE
Bugfix for parameter stripping when multiple `box_double()` (#96)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,10 @@
 all: build
 	cd build; make
 
+.PHONY:debug
+debug: build
+	cd build; cmake -DCMAKE_BUILD_TYPE:string=Debug ..; make
+
 .PHONY:test
 test: build
 	cd build; make check

--- a/src/parameters.c
+++ b/src/parameters.c
@@ -86,7 +86,7 @@ static bool begins_with(char *token, const char *beginning) {
     return strncmp(beginning, token, strlen(beginning)) == 0;
 }
 
-static void move_parameter_to_beginning_of(char *token, char *function_name, int parameter_length) {
+static void move_parameter_to_beginning_of(char *token, const char *function_name, int parameter_length) {
     memmove(token, token + strlen(function_name) + strlen("("), parameter_length+strlen(")")+1);
     *(end_of_token(token) - 1) = '\0';
 }

--- a/tests/parameters_tests.c
+++ b/tests/parameters_tests.c
@@ -75,6 +75,18 @@ Ensure(can_strip_two_box_doubles_to_leave_original_names) {
     assert_that((const char *)cgreen_vector_get(names, 1), is_equal_to_string("b"));
 }
 
+Ensure(can_strip_argument_and_box_double_to_leave_original_names) {
+    names = create_vector_of_names("a, box_double(b)");
+    assert_that((const char *)cgreen_vector_get(names, 0), is_equal_to_string("a"));
+    assert_that((const char *)cgreen_vector_get(names, 1), is_equal_to_string("b"));
+}
+
+Ensure(can_strip_box_double_and_argument_to_leave_original_names) {
+    names = create_vector_of_names("box_double(a), b");
+    assert_that((const char *)cgreen_vector_get(names, 0), is_equal_to_string("a"));
+    assert_that((const char *)cgreen_vector_get(names, 1), is_equal_to_string("b"));
+}
+
 Ensure(can_strip_d_macro_to_leave_original_name) {
     names = create_vector_of_names("d(a)");
     assert_that((const char *)cgreen_vector_get(names, 0), is_equal_to_string("a"));

--- a/tests/parameters_tests.c
+++ b/tests/parameters_tests.c
@@ -110,6 +110,17 @@ Ensure(can_strip_box_double_and_d_macro_to_leave_original_names) {
     assert_that((const char *)cgreen_vector_get(names, 1), is_equal_to_string("b"));
 }
 
+Ensure(can_strip_multiple_mixed_parameters_to_leave_original_names) {
+    names = create_vector_of_names("box_double(a), d(b), c, d,e,box_double(f),d(g)");
+    assert_that((const char *)cgreen_vector_get(names, 0), is_equal_to_string("a"));
+    assert_that((const char *)cgreen_vector_get(names, 1), is_equal_to_string("b"));
+    assert_that((const char *)cgreen_vector_get(names, 2), is_equal_to_string("c"));
+    assert_that((const char *)cgreen_vector_get(names, 3), is_equal_to_string("d"));
+    assert_that((const char *)cgreen_vector_get(names, 4), is_equal_to_string("e"));
+    assert_that((const char *)cgreen_vector_get(names, 5), is_equal_to_string("f"));
+    assert_that((const char *)cgreen_vector_get(names, 6), is_equal_to_string("g"));
+}
+
 TestSuite *parameter_tests() {
     TestSuite *suite = create_test_suite();
     set_teardown(suite, destroy_names);
@@ -127,5 +138,6 @@ TestSuite *parameter_tests() {
     add_test(suite, can_strip_two_d_macros_to_leave_original_names);
     add_test(suite, can_strip_d_macro_and_box_double_to_leave_original_names);
     add_test(suite, can_strip_box_double_and_d_macro_to_leave_original_names);
+    add_test(suite, can_strip_multiple_mixed_parameters_to_leave_original_names);
     return suite;
 }

--- a/tests/parameters_tests.c
+++ b/tests/parameters_tests.c
@@ -69,9 +69,33 @@ Ensure(can_strip_box_double_to_leave_original_name) {
     assert_that((const char *)cgreen_vector_get(names, 0), is_equal_to_string("a"));
 }
 
+Ensure(can_strip_two_box_doubles_to_leave_original_names) {
+    names = create_vector_of_names("box_double(a), box_double(b)");
+    assert_that((const char *)cgreen_vector_get(names, 0), is_equal_to_string("a"));
+    assert_that((const char *)cgreen_vector_get(names, 1), is_equal_to_string("b"));
+}
+
 Ensure(can_strip_d_macro_to_leave_original_name) {
     names = create_vector_of_names("d(a)");
     assert_that((const char *)cgreen_vector_get(names, 0), is_equal_to_string("a"));
+}
+
+Ensure(can_strip_two_d_macros_to_leave_original_names) {
+    names = create_vector_of_names("d(a), d(b)");
+    assert_that((const char *)cgreen_vector_get(names, 0), is_equal_to_string("a"));
+    assert_that((const char *)cgreen_vector_get(names, 1), is_equal_to_string("b"));
+}
+
+Ensure(can_strip_d_macro_and_box_double_to_leave_original_names) {
+    names = create_vector_of_names("d(a), box_double(b)");
+    assert_that((const char *)cgreen_vector_get(names, 0), is_equal_to_string("a"));
+    assert_that((const char *)cgreen_vector_get(names, 1), is_equal_to_string("b"));
+}
+
+Ensure(can_strip_box_double_and_d_macro_to_leave_original_names) {
+    names = create_vector_of_names("box_double(a), d(b)");
+    assert_that((const char *)cgreen_vector_get(names, 0), is_equal_to_string("a"));
+    assert_that((const char *)cgreen_vector_get(names, 1), is_equal_to_string("b"));
 }
 
 TestSuite *parameter_tests() {
@@ -86,6 +110,10 @@ TestSuite *parameter_tests() {
     add_test(suite, can_read_long_parameters_with_funky_names);
     add_test(suite, can_read_two_parameters_with_varied_whitespace);
     add_test(suite, can_strip_box_double_to_leave_original_name);
+    add_test(suite, can_strip_two_box_doubles_to_leave_original_names);
     add_test(suite, can_strip_d_macro_to_leave_original_name);
+    add_test(suite, can_strip_two_d_macros_to_leave_original_names);
+    add_test(suite, can_strip_d_macro_and_box_double_to_leave_original_names);
+    add_test(suite, can_strip_box_double_and_d_macro_to_leave_original_names);
     return suite;
 }


### PR DESCRIPTION
In #96 it was discovered that the designed way of using `box_double()` for double parameters to `mock()` was broken because the stripping produced spurious parameters.

This is a fix for that including some more tests to ensure it will never happen again ,-)