### PR TITLE
Remove superflous namespacing

### DIFF
--- a/src/assertions.c
+++ b/src/assertions.c
@@ -14,10 +14,6 @@
 
 #include "cgreen_value_internal.h"
 
-#ifdef __cplusplus
-namespace cgreen {
-#endif
-
 
 void assert_core_(const char *file, int line, const char *actual_string, intptr_t actual,
                   Constraint* constraint) {
@@ -184,9 +180,5 @@ const char *show_null_as_the_string_null(const char *string) {
     return (string == NULL ? "NULL" : string);
 }
 
-
-#ifdef __cplusplus
-} // namespace cgreen
-#endif
 
 /* vim: set ts=4 sw=4 et cindent: */

--- a/src/boxed_double.c
+++ b/src/boxed_double.c
@@ -2,10 +2,6 @@
 #include <stdint.h>
 #include <stdlib.h>
 
-#ifdef __cplusplus
-namespace cgreen {
-#endif
-
 /* NOTE: while returning BoxedDouble* here seems logical, it forces casts all over the place */
 intptr_t box_double(double value) {
     BoxedDouble *box = (BoxedDouble *) malloc(sizeof(BoxedDouble));
@@ -22,7 +18,3 @@ double unbox_double(intptr_t box) {
 double as_double(intptr_t box) {
     return ((BoxedDouble *)box)->value;
 }
-
-#ifdef __cplusplus
-} // namespace cgreen
-#endif

--- a/src/breadcrumb.c
+++ b/src/breadcrumb.c
@@ -1,9 +1,6 @@
 #include <cgreen/breadcrumb.h>
 #include <stdlib.h>
 
-#ifdef __cplusplus
-namespace cgreen {
-#endif
 
 CgreenBreadcrumb *create_breadcrumb(void) {
     CgreenBreadcrumb *breadcrumb = (CgreenBreadcrumb *) malloc(sizeof(CgreenBreadcrumb));
@@ -60,9 +57,5 @@ void walk_breadcrumb(CgreenBreadcrumb *breadcrumb, void (*walker)(const char *, 
         (*walker)(breadcrumb->trail[i], memo);
     }
 }
-
-#ifdef __cplusplus
-} // namespace cgreen
-#endif
 
 /* vim: set ts=4 sw=4 et cindent: */

--- a/src/cgreen_time.c
+++ b/src/cgreen_time.c
@@ -1,20 +1,13 @@
 #include "cgreen/internal/cgreen_time.h"
 #include <stdint.h>
 
-#ifdef __cplusplus
-namespace cgreen {
-#endif
-
-uint32_t cgreen_time_duration_in_milliseconds(uint32_t start_time_in_milliseconds, uint32_t end_time_in_milliseconds) {
+uint32_t cgreen_time_duration_in_milliseconds(uint32_t start_time_in_milliseconds,
+                                              uint32_t end_time_in_milliseconds) {
     if (end_time_in_milliseconds < start_time_in_milliseconds) {
         return 0;
     }
 
     return end_time_in_milliseconds - start_time_in_milliseconds;
 }
-
-#ifdef __cplusplus
-}  // namespace cgreen
-#endif
 
 

--- a/src/cgreen_value.c
+++ b/src/cgreen_value.c
@@ -2,41 +2,32 @@
 #include <stdint.h>
 #include <stdlib.h>
 
-#ifdef __cplusplus
-namespace cgreen {
-#endif
+CgreenValue *create_cgreen_value(CgreenValue value) {
+    CgreenValue *ptr = (CgreenValue*)malloc(sizeof(CgreenValue));
+    *ptr = value;
+    return ptr;
+}
 
-    CgreenValue *create_cgreen_value(CgreenValue value) {
-        CgreenValue *ptr = (CgreenValue*)malloc(sizeof(CgreenValue));
-        *ptr = value;
-        return ptr;
-    }
+CgreenValue make_cgreen_integer_value(intptr_t integer) {
+    CgreenValue value = {INTEGER, {0}};
+    value.value.integer_value = integer;
+    return value;
+}
 
-    CgreenValue make_cgreen_integer_value(intptr_t integer) {
-        CgreenValue value = {INTEGER, {0}};
-        value.value.integer_value = integer;
-        return value;
-    }
+CgreenValue make_cgreen_string_value(const char *string) {
+    CgreenValue value = {STRING, {0}};
+    value.value.string_value = string;
+    return value;
+}
 
-    CgreenValue make_cgreen_string_value(const char *string) {
-        CgreenValue value = {STRING, {0}};
-        value.value.string_value = string;
-        return value;
-    }
+CgreenValue make_cgreen_pointer_value(void *pointer) {
+    CgreenValue value = {POINTER, {0}};
+    value.value.pointer_value = pointer;
+    return value;
+}
 
-    CgreenValue make_cgreen_pointer_value(void *pointer) {
-        CgreenValue value = {POINTER, {0}};
-        value.value.pointer_value = pointer;
-        return value;
-    }
-
-    CgreenValue make_cgreen_double_value(double d) {
-        CgreenValue value = {DOUBLE, {0}};
-        value.value.double_value = d;
-        return value;
-    }
-
-
-#ifdef __cplusplus
-} // namespace cgreen
-#endif
+CgreenValue make_cgreen_double_value(double d) {
+    CgreenValue value = {DOUBLE, {0}};
+    value.value.double_value = d;
+    return value;
+}

--- a/src/cgreen_value_internal.h
+++ b/src/cgreen_value_internal.h
@@ -3,6 +3,7 @@
 
 #include <cgreen/cgreen_value.h>
 
+/* CgreenValues are used from some user level tests so must be compilable in C++ */
 #ifdef __cplusplus
 namespace cgreen {
     extern "C" {

--- a/src/constraint_syntax_helpers.c
+++ b/src/constraint_syntax_helpers.c
@@ -1,14 +1,9 @@
 #include <cgreen/constraint_syntax_helpers.h>
 #include <cgreen/constraint.h>
 #include <cgreen/message_formatting.h>
-#ifndef __cplusplus
 #include <stdbool.h>
-#endif
 #include <stddef.h>
 
-#ifdef __cplusplus
-namespace cgreen {
-#endif
 
 Constraint static_is_non_null_constraint = {
     /* .type */ VALUE_COMPARER,
@@ -74,9 +69,5 @@ Constraint *is_non_null = &static_is_non_null_constraint;
 Constraint *is_null = &static_is_null_constraint;
 Constraint *is_false = &static_is_false_constraint;
 Constraint *is_true = &static_is_true_constraint;
-
-#ifdef __cplusplus
-} // namespace cgreen
-#endif
 
 /* vim: set ts=4 sw=4 et cindent: */

--- a/src/local_messaging.cpp
+++ b/src/local_messaging.cpp
@@ -7,10 +7,9 @@
 #include <stack>
 #include <vector>
 #include <typeinfo>
-#ifdef __cplusplus
+
 namespace cgreen {
     extern "C" {
-#endif
 
 #define message_content_size(Type) (sizeof(Type) - sizeof(long))
 
@@ -81,10 +80,7 @@ int receive_cgreen_message(int messaging) {
 static void clean_up_messaging() {
     queue_count = 0;
 }
-
-#ifdef __cplusplus
 }
 } // namespace cgreen
-#endif
 
 /* vim: set ts=4 sw=4 et cindent: */

--- a/src/memory.c
+++ b/src/memory.c
@@ -1,12 +1,6 @@
 #include <stdlib.h>
 #include <string.h>
-// memory.h now co-located w/.c file
-//#include <cgreen/memory.h>
 #include "memory.h"
-
-#ifdef __cplusplus
-namespace cgreen {
-#endif
 
 #define MEMORY_INCREMENT 1024
 
@@ -75,14 +69,10 @@ static int move_to_front(MemoryPool *pool, void *pointer) {
     return 0;
 }
 
-static void move_up_one(void **blocks, long amount) {
-    if (amount == 0) {
-        return;
-    }
-    // FIXME: this doesn't compile and the smenatics might be wrong
-    //memmove(blocks[0], blocks[1], (size_t)(blocks[amount] - blocks[1]));
-}
-
-#ifdef __cplusplus
-} // namespace cgreen
-#endif
+/* static void move_up_one(void **blocks, long amount) { */
+/*     if (amount == 0) { */
+/*         return; */
+/*     } */
+/*     // FIXME: this doesn't compile and the semantics might be wrong */
+/*     //memmove(blocks[0], blocks[1], (size_t)(blocks[amount] - blocks[1])); */
+/* } */

--- a/src/memory.h
+++ b/src/memory.h
@@ -1,10 +1,6 @@
 #ifndef MEMORY_HEADER
 #define MEMORY_HEADER
 
-#ifdef __cplusplus
-namespace cgreen {
-    extern "C" {
-#endif
 
 typedef struct MemoryPool_ MemoryPool;
 
@@ -12,10 +8,5 @@ MemoryPool *create_memory_pool();
 void free_memory_pool(MemoryPool *pool);
 void *memory_pool_allocate(MemoryPool *pool, size_t bytes);
 void *memory_pool_reallocate(MemoryPool *pool, void *pointer, size_t bytes);
-
-#ifdef __cplusplus
-    }
-}
-#endif
 
 #endif

--- a/src/message_formatting.c
+++ b/src/message_formatting.c
@@ -17,9 +17,6 @@
 #include "wincompat.h"
 #endif
 
-#ifdef __cplusplus
-namespace cgreen {
-#endif
 
 // Handling of percent signs
 static const char *next_percent_sign(const char *s) {
@@ -278,7 +275,3 @@ char *failure_message_for(Constraint *constraint, const char *actual_string, int
 
     return message;
 }
-
-#ifdef __cplusplus
-}
-#endif

--- a/src/messaging.c
+++ b/src/messaging.c
@@ -19,9 +19,6 @@
 #include <sched.h>
 #endif
 
-#ifdef __cplusplus
-namespace cgreen {
-#endif
 
 #define message_content_size(Type) (sizeof(Type) - sizeof(long))
 
@@ -143,9 +140,5 @@ static void clean_up_messaging(void) {
     queues = NULL;
     queue_count = 0;
 }
-
-#ifdef __cplusplus
-} // namespace cgreen
-#endif
 
 /* vim: set ts=4 sw=4 et cindent: */

--- a/src/parameters.c
+++ b/src/parameters.c
@@ -6,9 +6,6 @@
 
 #include "parameters.h"
 
-#ifdef __cplusplus
-namespace cgreen {
-#endif
 #ifdef _MSC_VER
 //disable warning on windows
 //'strdup': The POSIX name for this item is deprecated. Instead, use the ISO C++ conformant name: _strdup.
@@ -143,9 +140,5 @@ static char *strip_function_from(char *token, const char *function_name) {
 
     return token;
 }
-
-#ifdef __cplusplus
-} // namespace cgreen
-#endif
 
 /* vim: set ts=4 sw=4 et cindent: */

--- a/src/parameters.h
+++ b/src/parameters.h
@@ -3,6 +3,7 @@
 
 #include <cgreen/vector.h>
 
+/* Parameters are used from some user level tests so must be compilable in C++ */
 #ifdef __cplusplus
 namespace cgreen {
     extern "C" {

--- a/src/posix_cgreen_pipe.c
+++ b/src/posix_cgreen_pipe.c
@@ -15,10 +15,6 @@
      /* One way to do it the old way is: ioctl(fd, FIOBIO, &flags); */
 #endif
 
-#ifdef __cplusplus
-namespace cgreen {
-#endif
-
 
 int cgreen_pipe_open(int pipes[2])
 {
@@ -71,10 +67,5 @@ ssize_t cgreen_pipe_write(int p, const void *buf, size_t count)
     }
     return pipe_write_result;
 }
-
-
-#ifdef __cplusplus
-} // namespace cgreen
-#endif
 
 /* vim: set ts=4 sw=4 et cindent: */

--- a/src/posix_cgreen_time.c
+++ b/src/posix_cgreen_time.c
@@ -15,10 +15,6 @@
 #  error "Your POSIX platform does not support gettimeofday(). Please report a bug to http://github.com/cgreen-devs/cgreen/issues"
 #endif
 
-#ifdef __cplusplus
-namespace cgreen {
-#endif
-
 #if defined(HAVE_GETTIMEOFDAY)
 uint32_t cgreen_time_get_current_milliseconds() {
 #ifdef __CYGWIN__
@@ -41,8 +37,5 @@ uint32_t cgreen_time_get_current_milliseconds() {
 }
 #endif
 
-#ifdef __cplusplus
-} // namespace cgreen
-#endif
 
 /* vim: set ts=4 sw=4 et cindent: */

--- a/src/posix_runner_platform.c
+++ b/src/posix_runner_platform.c
@@ -20,9 +20,6 @@
 #include "cgreen/internal/android_headers/androidcompat.h"
 #endif // #ifdef __ANDROID__
 
-#ifdef __cplusplus
-namespace cgreen {
-#endif
 
 typedef void (*sighandler_t)(int);
 
@@ -114,9 +111,5 @@ static void ignore_ctrl_c(void) {
 static void allow_ctrl_c(void) {
     signal(SIGINT, SIG_DFL);
 }
-
-#ifdef __cplusplus
-} // namespace cgreen
-#endif
 
 /* vim: set ts=4 sw=4 et cindent: */

--- a/src/runner.c
+++ b/src/runner.c
@@ -17,11 +17,6 @@
 #include "cgreen/internal/android_headers/androidcompat.h"
 #endif // #ifdef __ANDROID__
 
-#ifdef __cplusplus
-#include <stdexcept>
-
-namespace cgreen {
-#endif
 
 static const char* CGREEN_PER_TEST_TIMEOUT_ENVIRONMENT_VARIABLE = "CGREEN_PER_TEST_TIMEOUT";
 
@@ -317,9 +312,5 @@ void die(const char *message, ...) {
     va_end(arguments);
     exit(EXIT_FAILURE);
 }
-
-#ifdef __cplusplus
-} // namespace cgreen
-#endif
 
 /* vim: set ts=4 sw=4 et cindent: */

--- a/src/string_comparison.c
+++ b/src/string_comparison.c
@@ -5,9 +5,6 @@
 #include <stddef.h>
 #include <string.h>
 
-#ifdef __cplusplus
-namespace cgreen {
-#endif
 
 bool strings_are_equal(const char* actual, const char* expected) {
     /* TODO: if expected is null, warn user to use appropriate non-string assert instead */
@@ -30,8 +27,3 @@ bool string_contains(const char* actual, const char* expected) {
 
     return (strstr(actual, expected) != NULL);
 }
-
-
-#ifdef __cplusplus
-}
-#endif

--- a/src/suite.c
+++ b/src/suite.c
@@ -10,10 +10,6 @@
 
 #include "parameters.h"
 
-#ifdef __cplusplus
-namespace cgreen {
-#endif
-
 
 CgreenContext defaultContext = {
     /* name     */ "",
@@ -126,6 +122,3 @@ int count_tests(TestSuite *suite) {
     return count;
 }
 
-#ifdef __cplusplus
-}
-#endif

--- a/src/utils.c
+++ b/src/utils.c
@@ -2,10 +2,6 @@
 #include <string.h>
 #include "utils.h"
 
-#ifdef __cplusplus
-namespace cgreen {
-#endif
-
 
 char *string_dup(const char *string) {
     char *dup = (char *)malloc(strlen(string)+1);
@@ -13,7 +9,3 @@ char *string_dup(const char *string) {
         strcpy(dup, string);
     return dup;
 }
-
-#ifdef __cplusplus
-} // namespace cgreen
-#endif

--- a/src/utils.h
+++ b/src/utils.h
@@ -1,16 +1,6 @@
 #ifndef UTILS_HEADER
 #define UTILS_HEADER
 
-#ifdef __cplusplus
-namespace cgreen {
-    extern "C" {
-#endif
-
 char *string_dup(const char *original);
-
-#ifdef __cplusplus
-    }
-}
-#endif
 
 #endif

--- a/src/vector.c
+++ b/src/vector.c
@@ -6,10 +6,6 @@
 #include "cgreen/internal/android_headers/androidcompat.h"
 #endif // #ifdef __ANDROID__
 
-#ifdef __cplusplus
-namespace cgreen {
-#endif
-
 struct CgreenVector_ {
     int size;
     void (*destructor)(void *);
@@ -90,9 +86,5 @@ static void increase_space(CgreenVector *vector) {
     vector->space += 100;
     vector->items = (void**)realloc(vector->items, sizeof(void *) * vector->space);
 }
-
-#ifdef __cplusplus
-} // namespace cgreen
-#endif
 
 /* vim: set ts=4 sw=4 et cindent: */

--- a/src/win32_cgreen_pipe.c
+++ b/src/win32_cgreen_pipe.c
@@ -7,11 +7,6 @@
 #include <wincompat.h>
 
 
-#ifdef __cplusplus
-namespace cgreen {
-#endif
-
-
 ssize_t cgreen_pipe_read(int p, void *buf, size_t count)
 {
     DWORD bytesRead;
@@ -84,11 +79,6 @@ void cgreen_pipe_close(int p)
 {
     CloseHandle((HANDLE)p);
 }
-
-
-#ifdef __cplusplus
-} // namespace cgreen
-#endif
 
 #endif
 /* vim: set ts=4 sw=4 et cindent: */

--- a/src/win32_cgreen_time.c
+++ b/src/win32_cgreen_time.c
@@ -1,33 +1,24 @@
-
 #include "cgreen/internal/cgreen_time.h"
 #include <stdint.h>
 #include <stdio.h>
 #include <unistd.h>
 #include <windows.h>
 
-#ifdef __cplusplus
-namespace cgreen {
-#endif
+static LARGE_INTEGER qry_freq;
+static bool qry_freq_initialized = false;
 
-   static LARGE_INTEGER qry_freq;
-   static bool qry_freq_initialized = false;
+uint32_t cgreen_time_get_current_milliseconds() {
+    if (!qry_freq_initialized) {
+        QueryPerformanceFrequency(&qry_freq);
+        qry_freq_initialized = true;
+    }
 
-   uint32_t cgreen_time_get_current_milliseconds() {
-      if (!qry_freq_initialized) {
-         QueryPerformanceFrequency(&qry_freq);
-         qry_freq_initialized = true;
-      }
+    LARGE_INTEGER current_count;
+    QueryPerformanceCounter(&current_count);
 
-      LARGE_INTEGER current_count;
-      QueryPerformanceCounter(&current_count);
+    current_count.QuadPart = current_count.QuadPart * 1000000 / qry_freq.QuadPart;
 
-      current_count.QuadPart = current_count.QuadPart * 1000000 / qry_freq.QuadPart;
+    return trunc(current_count.QuadPart / 1000);
+}
 
-      return trunc(current_count.QuadPart / 1000);
-   }
-
-#ifdef __cplusplus
-} // namespace cgreen
-#endif
-
-  /* vim: set ts=4 sw=4 et cindent: */
+/* vim: set ts=4 sw=4 et cindent: */

--- a/src/win32_runner_platform.c
+++ b/src/win32_runner_platform.c
@@ -6,10 +6,6 @@
 #include "wincompat.h"
 #include "cgreen/internal/cgreen_time.h"
 
-#ifdef __cplusplus
-namespace cgreen {
-#endif
-
 
 #include "Strsafe.h"
 #define SECOND  (1000)
@@ -180,11 +176,6 @@ void run_test_in_its_own_process(TestSuite *suite, CgreenTest *test, TestReporte
 
     return;
 }
-
-
-#ifdef __cplusplus
-} // namespace cgreen
-#endif
 
 #endif
 /* vim: set ts=4 sw=4 et cindent: */

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -22,6 +22,13 @@ endif()
 
 
 # C tests, library to use with runner, and a main program
+# NOTE that some of these are "pure" unit tests which only
+# need to work in C, since Cgreen's internal is C.
+# Some others are actually testing user level functionality
+# which must work both for C and C++ compiles.
+# TODO: separate out those into separate dirs? Or just
+# two lists of files, one which should go into C++ compilation
+# too.
 set(c_tests_library_SRCS
   assertion_tests.c
   breadcrumb_tests.c

--- a/tests/constraint_tests.c
+++ b/tests/constraint_tests.c
@@ -68,6 +68,11 @@ Ensure(Constraint, compare_is_correct_when_using_integers) {
     destroy_constraint(is_equal_to_37);
 }
 
+Ensure(Constraint, compare_to_is_null_correctly) {
+    assert_that(NULL, is_null);
+    assert_that(14, is_not_null);
+}
+
 Ensure(Constraint, string_constraint_destroy_clears_state) {
     Constraint *string_constraint =
     		create_equal_to_string_constraint("Hello", "user_greeting");


### PR DESCRIPTION
Since we are now only compiling user level tests with C++ most of the ifdef´ed namespacing can be removed.