### PR TITLE
Cgreen mocker to generate casts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,6 +20,15 @@ all: build
 debug: build
 	cd build; cmake -DCMAKE_BUILD_TYPE:string=Debug ..; make
 
+# TODO: verify that we're not already on CygwinXX, in that case "make" should suffice
+.PHONY:cygwin32
+cygwin32: build
+	cd build; cmake -DCMAKE_C_COMPILER=i686-pc-cygwin-gcc -DCMAKE_CXX_COMPILER=i686-pc-cygwin-g++ -DCMAKE_INSTALL_BINDIR:string=bin32 -DCMAKE_INSTALL_LIBDIR:string=lib32 ..; make
+
+.PHONY:cygwin64
+cygwin64: build
+	cd build; cmake -DCMAKE_C_COMPILER=i686-pc-cygwin-gcc -DCMAKE_CXX_COMPILER=i686-pc-cygwin-g++ ..; make
+
 .PHONY:test
 test: build
 	cd build; make check

--- a/contrib/cgreen-mocker/Makefile
+++ b/contrib/cgreen-mocker/Makefile
@@ -1,14 +1,15 @@
 all:
 	@echo "With the command:"
-	@echo
+	@echo "-----------------"
 	./cgreen-mocker.py double.h > double.mock
-	@echo
+	@echo "-----------------"
 	@echo "'cgreen-mocker' reads a C header file and transforms any"
 	@echo "function declarations into corresponding Cgreen mocks."
 	@echo "Here's the input:"
-	@echo
+	@echo "-----------------"
 	@cat double.h
-	@echo
+	@echo "-----------------"
 	@echo "And here's the resulting mock declaration:"
-	@echo
+	@echo "------------------------------------------"
 	@cat double.mock
+	@echo "------------------------------------------"

--- a/contrib/cgreen-mocker/cgreen-mocker.py
+++ b/contrib/cgreen-mocker/cgreen-mocker.py
@@ -18,7 +18,9 @@
 # Since it uses pycparser it will only handle C functions
 # and you will probably need the pycparsers "fake_libc_include"
 # to avoid parsing the whole world of libc headers. You can
-# point to it using a command line 'cpp_directive' arg.
+# make a soft link in your directory to a copy of the pycparser
+# source, and cgreen-mocker will pick it up or you can point
+# to it using a command line 'cpp_directive' arg.
 #
 # You can find pycparser at https://github.com/eliben/pycparser
 #

--- a/contrib/cgreen-mocker/cgreen-mocker.py
+++ b/contrib/cgreen-mocker/cgreen-mocker.py
@@ -60,7 +60,7 @@ class FuncDefVisitor(c_ast.NodeVisitor):
         print()
 
 def arg_list(args):
-    if len(args.params) > 0:
+    if args != None and len(args.params) > 0:
         return [el for el in map(parameter_name_or_box_double, args.params) if el is not None]
     else:
         return []
@@ -72,10 +72,15 @@ def parameter_name_or_box_double(node):
         return node.name
 
 def should_return(node):
+    generator = c_generator.CGenerator()
     if isdouble_decl(node):
         print("  return unbox_double(", end="")
     elif not isvoid_decl(node):
-        print("  return ", end="")
+        print("  return (", end="")
+        print(generator.visit(node.type), end="")
+        if isinstance(node.type, c_ast.PtrDecl):
+            print(" *", end="")
+        print(") ", end="")
     else:
         print("  ", end="")
 

--- a/include/cgreen/CMakeLists.txt
+++ b/include/cgreen/CMakeLists.txt
@@ -4,6 +4,7 @@ set(cgreen_HDRS
   breadcrumb.h
   cdash_reporter.h
   cgreen.h
+  cgreen_value.h
   constraint.h
   constraint_syntax_helpers.h
   cpp_assertions.h


### PR DESCRIPTION
`cgreen-mocker` just generated `return mock()` which often generated a lot of warnings. This PR adds casts to (most cases) of returned mock values.