### PR TITLE
Protect against expressions in assertion statements.

### DIFF
--- a/include/cgreen/assertions.h
+++ b/include/cgreen/assertions.h
@@ -27,7 +27,7 @@ namespace cgreen {
 
 */
 #define assert_that(...) assert_that_NARG(__VA_ARGS__)(__VA_ARGS__)
-#define assert_that_double(actual, constraint) assert_that_double_(__FILE__, __LINE__, STRINGIFY_TOKEN(actual), (double)actual, constraint)
+#define assert_that_double(actual, constraint) assert_that_double_(__FILE__, __LINE__, STRINGIFY_TOKEN(actual), (double)(actual), (constraint))
 
 #define pass_test() assert_true(true)
 #define fail_test(...) assert_true_with_message(false, __VA_ARGS__)

--- a/include/cgreen/internal/assertions_internal.h
+++ b/include/cgreen/internal/assertions_internal.h
@@ -33,7 +33,7 @@ namespace cgreen {
 #define assert_that_NARG(...) ASSERT_THAT_macro_dispatcher(assert_that, __VA_ARGS__)
 
 #define assert_that_expression(expression) \
-        assert_core_(__FILE__, __LINE__, STRINGIFY_TOKEN(expression), expression, is_true);
+        assert_core_(__FILE__, __LINE__, STRINGIFY_TOKEN(expression), (expression), is_true);
 
 void assert_equal_(const char *file, int line, const char *expression, intptr_t tried, intptr_t expected);
 void assert_not_equal_(const char *file, int line, const char *expression, intptr_t tried, intptr_t expected);

--- a/include/cgreen/internal/c_assertions.h
+++ b/include/cgreen/internal/c_assertions.h
@@ -7,7 +7,7 @@
 #include "stringify_token.h"
 
 #ifndef __cplusplus
-#define assert_that_constraint(actual, constraint) assert_core_(__FILE__, __LINE__, STRINGIFY_TOKEN(actual), (intptr_t)actual, constraint)
+#define assert_that_constraint(actual, constraint) assert_core_(__FILE__, __LINE__, STRINGIFY_TOKEN(actual), (intptr_t)(actual), (constraint))
 #endif
 
 #ifdef __cplusplus

--- a/include/cgreen/legacy.h
+++ b/include/cgreen/legacy.h
@@ -6,37 +6,37 @@
 
 /* Legacy style asserts:*/
 #define assert_true(result) \
-        (*get_test_reporter()->assert_true)(get_test_reporter(), __FILE__, __LINE__, result, "[" STRINGIFY_TOKEN(result) "] should be true\n", NULL)
+        (*get_test_reporter()->assert_true)(get_test_reporter(), __FILE__, __LINE__, (result), "[" STRINGIFY_TOKEN(result) "] should be true\n", NULL)
 #define assert_false(result) \
-        (*get_test_reporter()->assert_true)(get_test_reporter(), __FILE__, __LINE__, ! result, "[" STRINGIFY_TOKEN(result) "] should be false\n", NULL)
+        (*get_test_reporter()->assert_true)(get_test_reporter(), __FILE__, __LINE__, ! (result), "[" STRINGIFY_TOKEN(result) "] should be false\n", NULL)
 #define assert_equal(tried, expected) \
-        assert_equal_(__FILE__, __LINE__, STRINGIFY_TOKEN(tried), (intptr_t)tried, (intptr_t)expected)
+        assert_equal_(__FILE__, __LINE__, STRINGIFY_TOKEN(tried), (intptr_t)(tried), (intptr_t)(expected))
 #define assert_not_equal(tried, expected) \
-        assert_not_equal_(__FILE__, __LINE__, STRINGIFY_TOKEN(tried), (intptr_t)tried, (intptr_t)expected)
+        assert_not_equal_(__FILE__, __LINE__, STRINGIFY_TOKEN(tried), (intptr_t)(tried), (intptr_t)(expected))
 #define assert_double_equal(tried, expected) \
-        assert_double_equal_(__FILE__, __LINE__, STRINGIFY_TOKEN(tried), tried, expected)
+        assert_double_equal_(__FILE__, __LINE__, STRINGIFY_TOKEN(tried), (tried), (expected))
 #define assert_double_not_equal(tried, expected) \
-        assert_double_not_equal_(__FILE__, __LINE__, STRINGIFY_TOKEN(tried), tried, expected)
+        assert_double_not_equal_(__FILE__, __LINE__, STRINGIFY_TOKEN(tried), (tried), (expected))
 #define assert_string_equal(tried, expected) \
-        assert_string_equal_(__FILE__, __LINE__, STRINGIFY_TOKEN(tried), tried, expected)
+        assert_string_equal_(__FILE__, __LINE__, STRINGIFY_TOKEN(tried), (tried), (expected))
 #define assert_string_not_equal(tried, expected) \
-        assert_string_not_equal_(__FILE__, __LINE__, STRINGIFY_TOKEN(tried), tried, expected)
+        assert_string_not_equal_(__FILE__, __LINE__, STRINGIFY_TOKEN(tried), (tried), (expected))
 
 #define assert_true_with_message(result, ...) \
-        (*get_test_reporter()->assert_true)(get_test_reporter(), __FILE__, __LINE__, result, __VA_ARGS__)
+        (*get_test_reporter()->assert_true)(get_test_reporter(), __FILE__, __LINE__, (result), __VA_ARGS__)
 #define assert_false_with_message(result, ...) \
-        (*get_test_reporter()->assert_true)(get_test_reporter(), __FILE__, __LINE__, ! result, __VA_ARGS__)
+        (*get_test_reporter()->assert_true)(get_test_reporter(), __FILE__, __LINE__, ! (result), __VA_ARGS__)
 #define assert_equal_with_message(tried, expected, ...) \
-        (*get_test_reporter()->assert_true)(get_test_reporter(), __FILE__, __LINE__, (tried == expected), __VA_ARGS__)
+        (*get_test_reporter()->assert_true)(get_test_reporter(), __FILE__, __LINE__, ((tried) == (expected)), __VA_ARGS__)
 #define assert_not_equal_with_message(tried, expected, ...) \
-        (*get_test_reporter()->assert_true)(get_test_reporter(), __FILE__, __LINE__, (tried != expected), __VA_ARGS__)
+        (*get_test_reporter()->assert_true)(get_test_reporter(), __FILE__, __LINE__, ((tried) != (expected)), __VA_ARGS__)
 #define assert_double_equal_with_message(tried, expected, ...) \
-        (*get_test_reporter()->assert_true)(get_test_reporter(), __FILE__, __LINE__, doubles_are_equal(tried, expected), __VA_ARGS__)
+        (*get_test_reporter()->assert_true)(get_test_reporter(), __FILE__, __LINE__, doubles_are_equal((tried), (expected)), __VA_ARGS__)
 #define assert_double_not_equal_with_message(tried, expected, ...) \
-        (*get_test_reporter()->assert_true)(get_test_reporter(), __FILE__, __LINE__, doubles_are_equal(tried, expected), __VA_ARGS__)
+        (*get_test_reporter()->assert_true)(get_test_reporter(), __FILE__, __LINE__, doubles_are_equal((tried), (expected)), __VA_ARGS__)
 #define assert_string_equal_with_message(tried, expected, ...) \
-        (*get_test_reporter()->assert_true)(get_test_reporter(), __FILE__, __LINE__, strings_are_equal(tried, expected), __VA_ARGS__)
+        (*get_test_reporter()->assert_true)(get_test_reporter(), __FILE__, __LINE__, strings_are_equal((tried), (expected)), __VA_ARGS__)
 #define assert_string_not_equal_with_message(tried, expected, ...) \
-        (*get_test_reporter()->assert_true)(get_test_reporter(), __FILE__, __LINE__, !strings_are_equal(tried, expected), __VA_ARGS__)
+        (*get_test_reporter()->assert_true)(get_test_reporter(), __FILE__, __LINE__, !strings_are_equal((tried), (expected)), __VA_ARGS__)
 
 #endif


### PR DESCRIPTION
As an example, without this change:
    assert_false(a == b)
ends up evaluating to:
    assert_true(!a == b)
The "!a" is evaluated before the "==".  What we really want to see is
    assert_true(!(a == b))