### PR TITLE
Use strict prototyping.

### DIFF
--- a/cmake/Modules/DefineCompilerFlags.cmake
+++ b/cmake/Modules/DefineCompilerFlags.cmake
@@ -13,7 +13,7 @@ if (UNIX)
     add_definitions(-Wall -Wextra -Wunused)
 
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++98 -Weffc++")
-    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -std=c99")
+    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -std=c99 -Wstrict-prototypes")
 
     if (CGREEN_INTERNAL_WITH_GCOV)
       set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -ftest-coverage -fprofile-arcs")

--- a/include/cgreen/assertions.h
+++ b/include/cgreen/assertions.h
@@ -34,7 +34,7 @@ namespace cgreen {
 
 
 /* Utility: */
-int get_significant_figures();
+int get_significant_figures(void);
 void significant_figures_for_assert_double_are(int figures);
 
 #include <cgreen/legacy.h>

--- a/include/cgreen/constraint.h
+++ b/include/cgreen/constraint.h
@@ -42,7 +42,7 @@ namespace cgreen {
     extern "C" {
 #endif
 
-Constraint *create_constraint();
+Constraint *create_constraint(void);
 Constraint *create_parameter_constraint_for(const char *parameter_name);
 
 void destroy_empty_constraint(Constraint *constraint);

--- a/include/cgreen/messaging.h
+++ b/include/cgreen/messaging.h
@@ -9,8 +9,8 @@ namespace cgreen {
 int start_cgreen_messaging(int tag);
 void send_cgreen_message(int messaging, int result);
 int receive_cgreen_message(int messaging);
-int get_pipe_read_handle();
-int get_pipe_write_handle();
+int get_pipe_read_handle(void);
+int get_pipe_write_handle(void);
 
 #ifdef __cplusplus
     }

--- a/src/suite.c
+++ b/src/suite.c
@@ -41,7 +41,7 @@ bool has_teardown(TestSuite *suite) {
 	return (suite->teardown != &do_nothing);
 }
 
-void do_nothing() {
+void do_nothing(void) {
 }
 
 TestSuite *create_named_test_suite_(const char *name, const char *filename, int line) {
@@ -101,11 +101,11 @@ void add_suite_(TestSuite *owner, const char *name, TestSuite *suite) {
     owner->tests[owner->size - 1].Runnable.suite = suite;
 }
 
-void set_setup(TestSuite *suite, void (*set_up)()) {
+void set_setup(TestSuite *suite, void (*set_up)(void)) {
     suite->setup = set_up;
 }
 
-void set_teardown(TestSuite *suite, void (*tear_down)()) {
+void set_teardown(TestSuite *suite, void (*tear_down)(void)) {
     suite->teardown = tear_down;
 }
 

--- a/tests/all_c_tests.c
+++ b/tests/all_c_tests.c
@@ -7,26 +7,26 @@
 using namespace cgreen;
 #endif
 
-TestSuite *assertion_tests();
-TestSuite *breadcrumb_tests();
-TestSuite *cdash_reporter_tests();
-TestSuite *collector_tests();
-TestSuite *constraint_tests();
+TestSuite *assertion_tests(void);
+TestSuite *breadcrumb_tests(void);
+TestSuite *cdash_reporter_tests(void);
+TestSuite *collector_tests(void);
+TestSuite *constraint_tests(void);
 #ifdef __cplusplus
-TestSuite *cpp_assertion_tests();
+TestSuite *cpp_assertion_tests(void);
 #endif
-TestSuite *cute_reporter_tests();
-TestSuite *cgreen_value_tests();
-TestSuite *message_formatting_tests();
-TestSuite *messaging_tests();
-TestSuite *mock_tests();
-TestSuite *parameter_tests();
-TestSuite *reflective_no_teardown_tests();
-TestSuite *reflective_tests();
-TestSuite *text_reporter_tests();
-TestSuite *unit_tests();
-TestSuite *vector_tests();
-TestSuite *xml_reporter_tests();
+TestSuite *cute_reporter_tests(void);
+TestSuite *cgreen_value_tests(void);
+TestSuite *message_formatting_tests(void);
+TestSuite *messaging_tests(void);
+TestSuite *mock_tests(void);
+TestSuite *parameter_tests(void);
+TestSuite *reflective_no_teardown_tests(void);
+TestSuite *reflective_tests(void);
+TestSuite *text_reporter_tests(void);
+TestSuite *unit_tests(void);
+TestSuite *vector_tests(void);
+TestSuite *xml_reporter_tests(void);
 
 int main(int argc, char **argv) {
     int suite_result;

--- a/tests/assertion_tests.c
+++ b/tests/assertion_tests.c
@@ -285,7 +285,7 @@ Ensure(return_value_constraints_are_not_allowed) {
 //    assert_that(0, will_return(1));
 }
 
-TestSuite *assertion_tests() {
+TestSuite *assertion_tests(void) {
     TestSuite *suite = create_test_suite();
     add_test(suite, integer_one_should_assert_true);
     add_test(suite, integer_zero_should_assert_false);

--- a/tests/breadcrumb_tests.c
+++ b/tests/breadcrumb_tests.c
@@ -9,11 +9,11 @@ using namespace cgreen;
 
 static CgreenBreadcrumb* breadcrumb;
 
-static void breadcrumb_tests_setup() {
+static void breadcrumb_tests_setup(void) {
     breadcrumb = create_breadcrumb();
 }
 
-static void breadcrumb_tests_teardown() {
+static void breadcrumb_tests_teardown(void) {
     destroy_breadcrumb(breadcrumb);
 }
 
@@ -80,7 +80,7 @@ Ensure(Breadcrumb, double_item_breadcrumb_does_calls_walker_only_once) {
     walk_breadcrumb(breadcrumb, &mock_walker, NULL);
 }
 
-TestSuite *breadcrumb_tests() {
+TestSuite *breadcrumb_tests(void) {
     TestSuite *suite = create_test_suite();
     set_setup(suite, breadcrumb_tests_setup);
 

--- a/tests/cdash_reporter_tests.c
+++ b/tests/cdash_reporter_tests.c
@@ -16,7 +16,7 @@ static const int line=666;
 static const uint32_t duration_in_milliseconds = 1;
 static char *output = NULL;
 
-static void clear_output()
+static void clear_output(void)
 {
     if (NULL != output) {
         free(output);
@@ -49,7 +49,7 @@ static TestReporter *reporter;
 
 static CDashInfo info;
 
-static void setup_cdash_reporter_tests() {
+static void setup_cdash_reporter_tests(void) {
     reporter = create_cdash_reporter(&info);
 
     // We can not use setup_reporting() since we are running
@@ -61,7 +61,7 @@ static void setup_cdash_reporter_tests() {
     set_cdash_reporter_printer(reporter, mocked_printer);
 }
 
-static void teardown_cdash_reporter_tests() {
+static void teardown_cdash_reporter_tests(void) {
     reporter->destroy(reporter);
 
     //bad mojo when running tests in same process, as destroy_reporter also sets
@@ -143,7 +143,7 @@ Ensure(CDashReporter, will_report_non_finishing_test) {
     assert_that(output, contains_string("<Test Status=\"incomplete\">"));
 }
 
-TestSuite *cdash_reporter_tests() {
+TestSuite *cdash_reporter_tests(void) {
     TestSuite *suite = create_test_suite();
     set_setup(suite, setup_cdash_reporter_tests);
 

--- a/tests/constraint_tests.c
+++ b/tests/constraint_tests.c
@@ -215,7 +215,7 @@ Ensure(Constraint, can_compare_to_hex) {
     assert_that((unsigned char)chars[0], is_equal_to_hex(0xaa));
 }
 
-TestSuite *constraint_tests() {
+TestSuite *constraint_tests(void) {
     TestSuite *suite = create_test_suite();
     add_test_with_context(suite, Constraint, default_destroy_clears_state);
     add_test_with_context(suite, Constraint, parameter_name_matches_correctly);

--- a/tests/cute_reporter_tests.c
+++ b/tests/cute_reporter_tests.c
@@ -18,7 +18,7 @@ static const int line=666;
 static const uint32_t duration_in_milliseconds = 1;
 static char *output = NULL;
 
-static void clear_output()
+static void clear_output(void)
 {
     if (NULL != output) {
         free(output);
@@ -47,7 +47,7 @@ static int mocked_printf(const char *format, ...) {
 
 static TestReporter *reporter;
 
-static void setup_cute_reporter_tests() {
+static void setup_cute_reporter_tests(void) {
     reporter = create_cute_reporter();
 
     // We can not use setup_reporting() since we are running
@@ -59,7 +59,7 @@ static void setup_cute_reporter_tests() {
     set_cute_reporter_printer(reporter, mocked_printf);
 }
 
-static void teardown_cute_reporter_tests() {
+static void teardown_cute_reporter_tests(void) {
     //bad mojo when running tests in same process, as destroy_reporter also sets
     //context.reporter = NULL, thus breaking the next test to run
     destroy_reporter(reporter);
@@ -71,7 +71,7 @@ static void teardown_cute_reporter_tests() {
     }
 }
 
-static void assert_no_output() {
+static void assert_no_output(void) {
     assert_that(strlen(output), is_equal_to(0));
 }
 
@@ -157,7 +157,7 @@ Ensure(CuteReporter, will_report_non_finishing_test) {
     assert_that(output, contains_string("failed to complete"));
 }
 
-TestSuite *cute_reporter_tests() {
+TestSuite *cute_reporter_tests(void) {
     TestSuite *suite = create_test_suite();
     set_setup(suite, setup_cute_reporter_tests);
 

--- a/tests/message_formatting_tests.c
+++ b/tests/message_formatting_tests.c
@@ -24,7 +24,7 @@ Ensure(MessageFormatting, can_show_failure_message_containing_percent_sign) {
     destroy_constraint(constraint);
 }
 
-TestSuite *message_formatting_tests() {
+TestSuite *message_formatting_tests(void) {
     TestSuite *suite = create_test_suite();
     add_test_with_context(suite, MessageFormatting, can_show_failure_message_containing_percent_sign);
     return suite;

--- a/tests/messaging_tests.c
+++ b/tests/messaging_tests.c
@@ -13,7 +13,7 @@ Ensure(highly_nested_test_suite_should_still_complete) {
     assert_that(true);
 }
 
-TestSuite *highly_nested_test_suite() {
+TestSuite *highly_nested_test_suite(void) {
     int i;
     TestSuite *suite = create_test_suite();
     add_test(suite, highly_nested_test_suite_should_still_complete);
@@ -56,7 +56,7 @@ Ensure(failure_reported_and_exception_thrown_when_messaging_would_block) {
     assert_that(loop, is_less_than(LOOPS));
 }
 
-TestSuite *messaging_tests() {
+TestSuite *messaging_tests(void) {
     TestSuite *suite = create_test_suite();
     add_suite(suite, highly_nested_test_suite());
     add_test(suite, can_send_message);

--- a/tests/mock_messages_tests.c
+++ b/tests/mock_messages_tests.c
@@ -12,7 +12,7 @@ Describe(Mocks);
 BeforeEach(Mocks) {}
 AfterEach(Mocks) {}
 
-static int integer_out() {
+static int integer_out(void) {
     return (int)mock();
 }
 

--- a/tests/mocks_tests.c
+++ b/tests/mocks_tests.c
@@ -12,7 +12,7 @@ Describe(Mocks);
 BeforeEach(Mocks) {}
 AfterEach(Mocks) {}
 
-static int integer_out() {
+static int integer_out(void) {
     return (int)mock();
 }
 
@@ -289,7 +289,7 @@ Ensure(Mocks, can_stub_an_out_parameter) {
 }
 
 // function which when mocked will be referred to by preprocessor macro
-static void function_macro_mock() {
+static void function_macro_mock(void) {
     mock();
 }
 
@@ -311,7 +311,7 @@ Ensure(Mocks, can_mock_a_function_macro) {
 #undef FUNCTION_MACRO
 
 
-TestSuite *mock_tests() {
+TestSuite *mock_tests(void) {
     TestSuite *suite = create_test_suite();
     add_test_with_context(suite, Mocks, default_return_value_when_no_presets_for_loose_mock);
     add_test_with_context(suite, Mocks, can_stub_an_integer_return);

--- a/tests/parameters_tests.c
+++ b/tests/parameters_tests.c
@@ -10,7 +10,7 @@ using namespace cgreen;
 
 static CgreenVector *names = NULL;
 
-void destroy_names() {
+void destroy_names(void) {
     destroy_cgreen_vector(names);
     names = NULL;
 }
@@ -149,7 +149,7 @@ Ensure(can_create_markers_for_mixed_parameters) {
     assert_that(*(bool*)cgreen_vector_get(markers, 4));
 }
 
-TestSuite *parameter_tests() {
+TestSuite *parameter_tests(void) {
     TestSuite *suite = create_test_suite();
     set_teardown(suite, destroy_names);
     add_test(suite, can_create_vector_of_no_parameters_and_destroy_it);

--- a/tests/reflective_runner_no_teardown_tests.c
+++ b/tests/reflective_runner_no_teardown_tests.c
@@ -23,7 +23,7 @@ Ensure(ReflectiveNoTeardownTest, second_test_unaffected_by_first) {
     assert_that(counter, is_equal_to(5));
 }
 
-TestSuite *reflective_no_teardown_tests() {
+TestSuite *reflective_no_teardown_tests(void) {
     TestSuite *suite = create_test_suite();
 
     add_test_with_context(suite, ReflectiveNoTeardownTest, before_called_implicitly_before_each_test);

--- a/tests/reflective_tests.c
+++ b/tests/reflective_tests.c
@@ -23,7 +23,7 @@ Ensure(ReflectiveRunner, running_first_test_does_not_affect_second_test) {
     assert_that(counter, is_equal_to(5));
 }
 
-TestSuite *reflective_tests() {
+TestSuite *reflective_tests(void) {
     TestSuite *suite = create_test_suite();
 
     add_test_with_context(suite, ReflectiveRunner, calls_setup_before_each_test);

--- a/tests/text_reporter_tests.c
+++ b/tests/text_reporter_tests.c
@@ -19,7 +19,7 @@ static const int line=666;
 static const uint32_t duration_in_milliseconds = 1;
 static char *output = NULL;
 
-static void clear_output()
+static void clear_output(void)
 {
     if (NULL != output) {
         free(output);
@@ -49,7 +49,7 @@ static int mocked_printer(const char *format, ...) {
 static TestReporter *reporter;
 
 
-static void text_reporter_tests_setup() {
+static void text_reporter_tests_setup(void) {
     reporter = create_text_reporter();
 
     // We can not use setup_reporting() since we are running
@@ -61,7 +61,7 @@ static void text_reporter_tests_setup() {
     set_text_reporter_printer(reporter, mocked_printer);
 }
 
-static void text_reporter_tests_teardown() {
+static void text_reporter_tests_teardown(void) {
     reporter->destroy(reporter);
 
     // bad mojo when running tests in same process, as destroy_reporter
@@ -142,7 +142,7 @@ Ensure(TextReporter, will_report_non_finishing_test) {
     assert_that(output, contains_string("1 exception"));
 }
 
-TestSuite *text_reporter_tests() {
+TestSuite *text_reporter_tests(void) {
     TestSuite *suite = create_test_suite();
     set_setup(suite, text_reporter_tests_setup);
 

--- a/tests/unit_tests.c
+++ b/tests/unit_tests.c
@@ -10,11 +10,11 @@ using namespace cgreen;
 
 static TestSuite* suite;
 
-static void unit_tests_setup() {
+static void unit_tests_setup(void) {
     suite = create_test_suite();
 }
 
-static void unit_tests_teardown() {
+static void unit_tests_teardown(void) {
     destroy_test_suite(suite);
 }
 
@@ -49,7 +49,7 @@ Ensure(Unittests, count_tests_return_four_for_four_nested_suite_with_one_testcas
 	assert_that(count_tests(suite), is_equal_to(4));
 }
 
-TestSuite *unit_tests() {
+TestSuite *unit_tests(void) {
 	TestSuite *suite = create_test_suite();
 	set_setup(suite, unit_tests_setup);
 

--- a/tests/vector_tests.c
+++ b/tests/vector_tests.c
@@ -10,12 +10,12 @@ static CgreenVector *vector;
 static char a = 'a', b = 'b', c = 'c';
 static int times_called = 0;
 
-static void set_up_vector() {
+static void set_up_vector(void) {
     vector = create_cgreen_vector(NULL);
     times_called = 0;
 }
 
-static void tear_down_vector() {
+static void tear_down_vector(void) {
     destroy_cgreen_vector(vector);
 }
 
@@ -130,7 +130,7 @@ Ensure(Vector, returns_null_for_remove_from_illegal_index) {
     assert_that(cgreen_vector_remove(vector, 1), is_equal_to(NULL));
 }
 
-TestSuite *vector_tests() {
+TestSuite *vector_tests(void) {
     TestSuite *suite = create_test_suite();
     set_setup(suite, set_up_vector);
     set_teardown(suite, tear_down_vector);

--- a/tests/xml_reporter_tests.c
+++ b/tests/xml_reporter_tests.c
@@ -18,7 +18,7 @@ static const int line=666;
 static const uint32_t duration_in_milliseconds = 1;
 static char *output = NULL;
 
-static void clear_output()
+static void clear_output(void)
 {
     if (NULL != output) {
         free(output);
@@ -48,7 +48,7 @@ static int mocked_printf(FILE *file, const char *format, ...) {
 
 static TestReporter *reporter;
 
-static void setup_xml_reporter_tests() {
+static void setup_xml_reporter_tests(void) {
     reporter = create_xml_reporter("PREFIX");
 
     // We can not use setup_reporting() since we are running
@@ -60,7 +60,7 @@ static void setup_xml_reporter_tests() {
     set_xml_reporter_printer(reporter, mocked_printf);
 }
 
-static void teardown_xml_reporter_tests() {
+static void teardown_xml_reporter_tests(void) {
     //bad mojo when running tests in same process, as destroy_reporter also sets
     //context.reporter = NULL, thus breaking the next test to run
     destroy_reporter(reporter);
@@ -157,7 +157,7 @@ Ensure(XmlReporter, will_report_non_finishing_test) {
 }
 
 
-TestSuite *xml_reporter_tests() {
+TestSuite *xml_reporter_tests(void) {
     TestSuite *suite = create_test_suite();
     set_setup(suite, setup_xml_reporter_tests);
 

--- a/tools/cgreen-runner.c
+++ b/tools/cgreen-runner.c
@@ -52,7 +52,7 @@ static void *options = NULL;
 static TestReporter *reporter = NULL;
 static TextReporterOptions reporter_options;
 
-static void cleanup()
+static void cleanup(void)
 {
     if (reporter) reporter->destroy(reporter);
     if (options) free(options);


### PR DESCRIPTION
Be explicit for protypes of functions that take no arguments.  This allows
the compiler to be more rigid in checking that the functions are called
correctly.