### PR TITLE
text-reporter:  Only report summary from top-level suite.

### DIFF
--- a/include/cgreen/reporter.h
+++ b/include/cgreen/reporter.h
@@ -20,13 +20,18 @@ struct TestReporter_ {
     void (*assert_true)(TestReporter *reporter, const char *file, int line,
                         int result, const char * message, ...);
     void (*finish_test)(TestReporter *reporter, const char *file, int line,
-                        const char *message, uint32_t duration_in_milliseconds);
-    void (*finish_suite)(TestReporter *reporter, const char *file, int line,
-                         uint32_t milliseconds);
+                        const char *message);
+    void (*finish_suite)(TestReporter *reporter, const char *file, int line);
     int passes;
     int failures;
     int exceptions;
     int skips;
+    uint32_t duration;
+    int total_passes;
+    int total_failures;
+    int total_exceptions;
+    int total_skips;
+    uint32_t total_duration;
     CgreenBreadcrumb *breadcrumb;
     int ipc;
     void *memo;
@@ -48,9 +53,8 @@ void destroy_reporter(TestReporter *reporter);
 void destroy_memo(TestReportMemo *memo);
 void reporter_start_test(TestReporter *reporter, const char *name);
 void reporter_start_suite(TestReporter *reporter, const char *name, const int count);
-void reporter_finish_test(TestReporter *reporter, const char *filename, int line, const char *message,
-                     uint32_t duration_in_milliseconds);
-void reporter_finish_suite(TestReporter *reporter, const char *filename, int line, uint32_t duration_in_milliseconds);
+void reporter_finish_test(TestReporter *reporter, const char *filename, int line, const char *message);
+void reporter_finish_suite(TestReporter *reporter, const char *filename, int line);
 void add_reporter_result(TestReporter *reporter, int result);
 void send_reporter_exception_notification(TestReporter *reporter);
 void send_reporter_skipped_notification(TestReporter *reporter);

--- a/src/cdash_reporter.c
+++ b/src/cdash_reporter.c
@@ -42,9 +42,8 @@ static void cdash_show_pass(TestReporter *reporter, const char *file, int line, 
 static void cdash_show_incomplete(TestReporter *reporter, const char *file, int line, const char *message, va_list arguments);
 
 static void cdash_finish_test(TestReporter *reporter, const char *filename, int line,
-                                             const char *message, uint32_t duration_in_milliseconds);
-static void cdash_finish_suite(TestReporter *reporter, const char *filename, int line,
-                                          uint32_t duration_in_milliseconds);
+                                             const char *message);
+static void cdash_finish_suite(TestReporter *reporter, const char *filename, int line);
 
 static time_t cdash_build_stamp(char *sbuildstamp, size_t sb);
 static time_t cdash_current_time(char *strtime);
@@ -177,6 +176,11 @@ static void cdash_destroy_reporter(TestReporter *reporter) {
 static void cdash_reporter_start_suite(TestReporter *reporter, const char *name, const int number_of_tests) {
     (void)number_of_tests;
 
+    reporter->passes = 0;
+    reporter->failures = 0;
+    reporter->skips = 0;
+    reporter->exceptions = 0;
+
     reporter_start_test(reporter, name);
 }
 
@@ -294,14 +298,18 @@ static void cdash_show_incomplete(TestReporter *reporter, const char *file, int 
 
 
 static void cdash_finish_test(TestReporter *reporter, const char *filename, int line,
-                                             const char *message, uint32_t duration_in_milliseconds) {
-    reporter_finish_test(reporter, filename, line, message, duration_in_milliseconds);
+                                             const char *message) {
+    reporter_finish_test(reporter, filename, line, message);
 }
 
 
-static void cdash_finish_suite(TestReporter *reporter, const char *filename, int line,
-                                          uint32_t duration_in_milliseconds) {
-    reporter_finish_test(reporter, filename, line, NULL, duration_in_milliseconds);
+static void cdash_finish_suite(TestReporter *reporter, const char *filename, int line) {
+    reporter_finish_test(reporter, filename, line, NULL);
+
+    reporter->total_passes += reporter->passes;
+    reporter->total_failures += reporter->failures;
+    reporter->total_skips += reporter->skips;
+    reporter->total_exceptions += reporter->exceptions;
 }
 
 static time_t cdash_build_stamp(char *sbuildstamp, size_t sb) {

--- a/src/posix_runner_platform.c
+++ b/src/posix_runner_platform.c
@@ -36,14 +36,14 @@ void run_test_in_its_own_process(TestSuite *suite, CgreenTest *test, TestReporte
     (*reporter->start_test)(reporter, test->name);
     if (test->skip) {
         send_reporter_skipped_notification(reporter);
-        (*reporter->finish_test)(reporter, test->filename, test->line, NULL, 0);
+        (*reporter->finish_test)(reporter, test->filename, test->line, NULL);
     } else if (in_child_process()) {
         run_the_test_code(suite, test, reporter);
         send_reporter_completion_notification(reporter);
         stop();
     } else {
         const int status = wait_for_child_process();
-        uint32_t test_duration = cgreen_time_duration_in_milliseconds(test_starting_milliseconds,
+        reporter->duration = cgreen_time_duration_in_milliseconds(test_starting_milliseconds,
                                                                       cgreen_time_get_current_milliseconds());
         if (WIFSIGNALED(status)) {
             /* a C++ exception generates SIGABRT. Only print our special message for other signals. */
@@ -51,12 +51,12 @@ void run_test_in_its_own_process(TestSuite *suite, CgreenTest *test, TestReporte
             if (sig != SIGABRT) {
                 char buf[128];
                 snprintf(buf, sizeof(buf), "Test terminated with signal: %s", (const char *)strsignal(sig));
-                (*reporter->finish_test)(reporter, test->filename, test->line, buf, test_duration);
+                (*reporter->finish_test)(reporter, test->filename, test->line, buf);
                 return;
             }
         }
 
-        (*reporter->finish_test)(reporter, test->filename, test->line, NULL, test_duration);
+        (*reporter->finish_test)(reporter, test->filename, test->line, NULL);
     }
 }
 

--- a/src/reporter.c
+++ b/src/reporter.c
@@ -71,6 +71,12 @@ TestReporter *create_reporter() {
     reporter->skips = 0;
     reporter->failures = 0;
     reporter->exceptions = 0;
+    reporter->duration = 0;
+    reporter->total_passes = 0;
+    reporter->total_skips = 0;
+    reporter->total_failures = 0;
+    reporter->total_exceptions = 0;
+    reporter->total_duration = 0;
     reporter->breadcrumb = breadcrumb;
     reporter->memo = NULL;
     reporter->options = NULL;
@@ -104,9 +110,7 @@ void reporter_start_suite(TestReporter *reporter, const char *name, const int co
     push_breadcrumb((CgreenBreadcrumb *) reporter->breadcrumb, name);
 }
 
-void reporter_finish_test(TestReporter *reporter, const char *filename, int line, const char *message,
-                          uint32_t duration_in_milliseconds) {
-    (void)duration_in_milliseconds;
+void reporter_finish_test(TestReporter *reporter, const char *filename, int line, const char *message) {
     int status = read_reporter_results(reporter);
 
     if (status == FINISH_TEST_SKIPPED) {
@@ -121,10 +125,9 @@ void reporter_finish_test(TestReporter *reporter, const char *filename, int line
     pop_breadcrumb((CgreenBreadcrumb *)reporter->breadcrumb);
 }
 
-void reporter_finish_suite(TestReporter *reporter, const char *filename, int line, uint32_t duration_in_milliseconds) {
+void reporter_finish_suite(TestReporter *reporter, const char *filename, int line) {
     (void)filename;
     (void)line;
-    (void)duration_in_milliseconds;
 
     read_reporter_results(reporter);
     pop_breadcrumb((CgreenBreadcrumb *)reporter->breadcrumb);

--- a/src/runner.c
+++ b/src/runner.c
@@ -55,59 +55,88 @@ int run_single_test(TestSuite *suite, const char *name, TestReporter *reporter) 
 
 static void run_every_test(TestSuite *suite, TestReporter *reporter) {
     int i;
-    uint32_t test_duration;
 
     run_specified_test_if_child(suite, reporter);
 
-    uint32_t test_starting_milliseconds = cgreen_time_get_current_milliseconds();
+    uint32_t total_test_starting_milliseconds = cgreen_time_get_current_milliseconds();
     (*reporter->start_suite)(reporter, suite->name, count_tests(suite));
+
+    // Run sub-suites first
     for (i = 0; i < suite->size; i++) {
-        if (suite->tests[i].type == test_function) {
-            if (getenv("CGREEN_NO_FORK") == NULL)
-                run_test_in_its_own_process(suite, suite->tests[i].Runnable.test, reporter);
-            else
-                run_test_in_the_current_process(suite, suite->tests[i].Runnable.test, reporter);
-        } else {
+        if (suite->tests[i].type != test_function) {
             (*suite->setup)();
             run_every_test(suite->tests[i].Runnable.suite, reporter);
             (*suite->teardown)();
         }
     }
 
-    test_duration = cgreen_time_duration_in_milliseconds(test_starting_milliseconds,
+    // Reset counters for top-level tests
+    reporter->passes = 0;
+    reporter->failures = 0;
+    reporter->skips = 0;
+    reporter->exceptions = 0;
+
+    uint32_t test_starting_milliseconds = cgreen_time_get_current_milliseconds();
+
+    // Run top-level tests
+    for (i = 0; i < suite->size; i++) {
+        if (suite->tests[i].type == test_function) {
+            if (getenv("CGREEN_NO_FORK") == NULL)
+                run_test_in_its_own_process(suite, suite->tests[i].Runnable.test, reporter);
+            else
+                run_test_in_the_current_process(suite, suite->tests[i].Runnable.test, reporter);
+        }
+    }
+
+    reporter->duration = cgreen_time_duration_in_milliseconds(test_starting_milliseconds,
+                                                                  cgreen_time_get_current_milliseconds());
+    reporter->total_duration = cgreen_time_duration_in_milliseconds(total_test_starting_milliseconds,
                                                                   cgreen_time_get_current_milliseconds());
     send_reporter_completion_notification(reporter);
-    (*reporter->finish_suite)(reporter, suite->filename, suite->line, test_duration);
+    (*reporter->finish_suite)(reporter, suite->filename, suite->line);
 }
 
 static void run_named_test(TestSuite *suite, const char *name, TestReporter *reporter) {
     int i;
-    uint32_t test_duration;
-    uint32_t test_starting_milliseconds = cgreen_time_get_current_milliseconds();
+
+    uint32_t total_test_starting_milliseconds = cgreen_time_get_current_milliseconds();
 
     (*reporter->start_suite)(reporter, suite->name, count_tests(suite));
     for (i = 0; i < suite->size; i++) {
-        if (suite->tests[i].type == test_function) {
-            if (strcmp(suite->tests[i].name, name) == 0) {
-                run_test_in_the_current_process(suite, suite->tests[i].Runnable.test, reporter);
-            }
-        } else if (has_test(suite->tests[i].Runnable.suite, name)) {
+        if (has_test(suite->tests[i].Runnable.suite, name)) {
             (*suite->setup)();
             run_named_test(suite->tests[i].Runnable.suite, name, reporter);
             (*suite->teardown)();
         }
     }
 
-    test_duration = cgreen_time_duration_in_milliseconds(test_starting_milliseconds,
+    // Reset counters for top-level tests
+    reporter->passes = 0;
+    reporter->failures = 0;
+    reporter->skips = 0;
+    reporter->exceptions = 0;
+
+    uint32_t test_starting_milliseconds = cgreen_time_get_current_milliseconds();
+
+    for (i = 0; i < suite->size; i++) {
+        if (suite->tests[i].type == test_function) {
+            if (strcmp(suite->tests[i].name, name) == 0) {
+                run_test_in_the_current_process(suite, suite->tests[i].Runnable.test, reporter);
+            }
+        }
+    }
+
+    reporter->duration = cgreen_time_duration_in_milliseconds(test_starting_milliseconds,
+                                                                  cgreen_time_get_current_milliseconds());
+    reporter->total_duration = cgreen_time_duration_in_milliseconds(total_test_starting_milliseconds,
                                                                   cgreen_time_get_current_milliseconds());
 
     send_reporter_completion_notification(reporter);
-    (*reporter->finish_suite)(reporter, suite->filename, suite->line, test_duration);
+    (*reporter->finish_suite)(reporter, suite->filename, suite->line);
 }
 
 
 static void run_test_in_the_current_process(TestSuite *suite, CgreenTest *test, TestReporter *reporter) {
-    uint32_t test_duration = 0;
     uint32_t test_starting_milliseconds = cgreen_time_get_current_milliseconds();
 
     (*reporter->start_test)(reporter, test->name);
@@ -115,12 +144,12 @@ static void run_test_in_the_current_process(TestSuite *suite, CgreenTest *test, 
         send_reporter_skipped_notification(reporter);
     } else {
         run_the_test_code(suite, test, reporter);
-        test_duration = cgreen_time_duration_in_milliseconds(test_starting_milliseconds,
+        reporter->duration = cgreen_time_duration_in_milliseconds(test_starting_milliseconds,
                                                              cgreen_time_get_current_milliseconds());
 
         send_reporter_completion_notification(reporter);
     }
-    (*reporter->finish_test)(reporter, test->filename, test->line, NULL, test_duration);
+    (*reporter->finish_test)(reporter, test->filename, test->line, NULL);
 }
 
 static int per_test_timeout_defined() {

--- a/src/runner.c
+++ b/src/runner.c
@@ -103,7 +103,8 @@ static void run_named_test(TestSuite *suite, const char *name, TestReporter *rep
 
     (*reporter->start_suite)(reporter, suite->name, count_tests(suite));
     for (i = 0; i < suite->size; i++) {
-        if (has_test(suite->tests[i].Runnable.suite, name)) {
+        if (suite->tests[i].type != test_function &&
+                has_test(suite->tests[i].Runnable.suite, name)) {
             (*suite->setup)();
             run_named_test(suite->tests[i].Runnable.suite, name, reporter);
             (*suite->teardown)();

--- a/src/text_reporter.c
+++ b/src/text_reporter.c
@@ -164,23 +164,25 @@ static void text_reporter_finish_suite(TestReporter *reporter, const char *file,
             memo->printer(RESET);
         }
     } else {
-        char buf[1000];
-        sprintf(buf, "Completed \"%s\": ", name);
-        if (reporter->passes)
-            strcat(buf, format_passes(reporter->passes, use_colors));
-        if (reporter->skips) {
-            insert_comma(buf);
-            strcat(buf, format_skips(reporter->skips, use_colors));
+        if (get_breadcrumb_depth((CgreenBreadcrumb *) reporter->breadcrumb) == 0) {
+            char buf[1000];
+            sprintf(buf, "Completed \"%s\": ", name);
+            if (reporter->passes)
+                strcat(buf, format_passes(reporter->passes, use_colors));
+            if (reporter->skips) {
+                insert_comma(buf);
+                strcat(buf, format_skips(reporter->skips, use_colors));
+            }
+            if (reporter->failures) {
+                insert_comma(buf);
+                strcat(buf, format_failures(reporter->failures, use_colors));
+            }
+            if (reporter->exceptions) {
+                insert_comma(buf);
+                strcat(buf, format_exceptions(reporter->exceptions, use_colors));
+            }
+            memo->printer("%s in %dms.\n", buf, duration_in_milliseconds);
         }
-        if (reporter->failures) {
-            insert_comma(buf);
-            strcat(buf, format_failures(reporter->failures, use_colors));
-        }
-        if (reporter->exceptions) {
-            insert_comma(buf);
-            strcat(buf, format_exceptions(reporter->exceptions, use_colors));
-        }
-        memo->printer("%s in %dms.\n", buf, duration_in_milliseconds);
     }
 }
 

--- a/src/text_reporter.c
+++ b/src/text_reporter.c
@@ -23,14 +23,13 @@ static void text_reporter_start_suite(TestReporter *reporter, const char *name,
         const int number_of_tests);
 static void text_reporter_start_test(TestReporter *reporter, const char *name);
 static void text_reporter_finish(TestReporter *reporter, const char *filename,
-        int line, const char *message, uint32_t duration_in_milliseconds);
+        int line, const char *message);
 static void show_fail(TestReporter *reporter, const char *file, int line,
         const char *message, va_list arguments);
 static void show_incomplete(TestReporter *reporter, const char *file, int line,
         const char *message, va_list arguments);
 static void show_breadcrumb(const char *name, void *memo);
-static void text_reporter_finish_suite(TestReporter *reporter, const char *file, int line,
-                                       uint32_t duration_in_milliseconds);
+static void text_reporter_finish_suite(TestReporter *reporter, const char *file, int line);
 
 
 /* To be able to run a reporter as CUT for testing with Cgreen itself
@@ -89,6 +88,11 @@ static void text_reporter_start_suite(TestReporter *reporter, const char *name,
 		const int number_of_tests) {
     TextMemo *memo = (TextMemo *)reporter->memo;
     
+    reporter->passes = 0;
+    reporter->failures = 0;
+    reporter->skips = 0;
+    reporter->exceptions = 0;
+
     reporter_start_test(reporter, name);
     if (get_breadcrumb_depth((CgreenBreadcrumb *) reporter->breadcrumb) == 1) {
         if (!have_quiet_mode(reporter))
@@ -104,8 +108,8 @@ static void text_reporter_start_test(TestReporter *reporter, const char *name) {
 }
 
 static void text_reporter_finish(TestReporter *reporter, const char *filename,
-        int line, const char *message, uint32_t duration_in_milliseconds) {
-    reporter_finish_test(reporter, filename, line, message, duration_in_milliseconds);
+        int line, const char *message) {
+    reporter_finish_test(reporter, filename, line, message);
 }
 
 
@@ -139,19 +143,54 @@ static char *format_exceptions(int exceptions, bool use_colors) {
     return buff;
 }
 
+static char *format_duration(uint32_t duration) {
+    static char buff[100];
+    snprintf(buff, sizeof(buff), " in %dms", duration);
+    return buff;
+}
 
 static void insert_comma(char buf[]) {
     if (buf[strlen(buf)-1] != ' ')
         strcat(buf, ", ");
 }
 
+static void text_reporter_print_results(char *buf, char *prepend,
+    int passes, int failures, int skips, int exceptions, uint32_t duration,
+    bool use_colors) {
 
-static void text_reporter_finish_suite(TestReporter *reporter, const char *file, int line, uint32_t duration_in_milliseconds) {
+    sprintf(buf, "%s", prepend);
+    if (passes || failures || skips || exceptions) {
+        if (passes)
+            strcat(buf, format_passes(passes, use_colors));
+        if (skips) {
+            insert_comma(buf);
+            strcat(buf, format_skips(skips, use_colors));
+        }
+        if (failures) {
+            insert_comma(buf);
+            strcat(buf, format_failures(failures, use_colors));
+        }
+        if (exceptions) {
+            insert_comma(buf);
+            strcat(buf, format_exceptions(exceptions, use_colors));
+        }
+        strcat(buf, format_duration(duration));
+    } else {
+        strcat(buf, "No tests");
+    }
+}
+
+static void text_reporter_finish_suite(TestReporter *reporter, const char *file, int line) {
     const char *name = get_current_from_breadcrumb((CgreenBreadcrumb *) reporter->breadcrumb);
     bool use_colors = reporter->options && ((TextReporterOptions *)reporter->options)->use_colours;
     TextMemo *memo = (TextMemo *)reporter->memo;
     
-    reporter_finish_suite(reporter, file, line, duration_in_milliseconds);
+    reporter_finish_suite(reporter, file, line);
+
+    reporter->total_passes += reporter->passes;
+    reporter->total_failures += reporter->failures;
+    reporter->total_skips += reporter->skips;
+    reporter->total_exceptions += reporter->exceptions;
 
     if (have_quiet_mode(reporter)) {
         if (use_colors) {
@@ -164,39 +203,50 @@ static void text_reporter_finish_suite(TestReporter *reporter, const char *file,
             memo->printer(RESET);
         }
     } else {
+        char buf[1000];
+        char prepend[100];
+
+        sprintf(prepend, "  \"%s\": ", name);
+        text_reporter_print_results(buf, prepend,
+                reporter->passes,
+                reporter->failures,
+                reporter->skips,
+                reporter->exceptions,
+                reporter->duration,
+                use_colors);
+
+        // Don't report top-level (pseudo-suite) if it had no tests
+        if (get_breadcrumb_depth((CgreenBreadcrumb *) reporter->breadcrumb) != 0 ||
+                (reporter->passes || reporter->failures || reporter->skips || reporter->exceptions)) {
+            memo->printer("%s.\n", buf);
+        }
+
+        // Report totals
         if (get_breadcrumb_depth((CgreenBreadcrumb *) reporter->breadcrumb) == 0) {
-            char buf[1000];
-            sprintf(buf, "Completed \"%s\": ", name);
-            if (reporter->passes)
-                strcat(buf, format_passes(reporter->passes, use_colors));
-            if (reporter->skips) {
-                insert_comma(buf);
-                strcat(buf, format_skips(reporter->skips, use_colors));
-            }
-            if (reporter->failures) {
-                insert_comma(buf);
-                strcat(buf, format_failures(reporter->failures, use_colors));
-            }
-            if (reporter->exceptions) {
-                insert_comma(buf);
-                strcat(buf, format_exceptions(reporter->exceptions, use_colors));
-            }
-            memo->printer("%s in %dms.\n", buf, duration_in_milliseconds);
+            sprintf(prepend, "Completed \"%s\": ", name);
+            text_reporter_print_results(buf, prepend,
+                    reporter->total_passes,
+                    reporter->total_failures,
+                    reporter->total_skips,
+                    reporter->total_exceptions,
+                    reporter->total_duration,
+                    use_colors);
+            memo->printer("%s.\n", buf);
         }
     }
 }
 
 static void show_fail(TestReporter *reporter, const char *file, int line,
-		const char *message, va_list arguments) {
-    char buffer[1000];
-    TextMemo *memo = (TextMemo *)reporter->memo;
-    memo->printer("%s:%d: ", file, line);
-    memo->printer("Failure: ");
-    memo->depth = 0;
-    walk_breadcrumb((CgreenBreadcrumb *) reporter->breadcrumb, &show_breadcrumb, memo);
-    memo->printer("\n\t");
-    // Simplify *printf statements for more robust cross-platform logging
-    if (message == NULL) {
+        const char *message, va_list arguments) {
+        char buffer[1000];
+        TextMemo *memo = (TextMemo *)reporter->memo;
+        memo->printer("%s:%d: ", file, line);
+        memo->printer("Failure: ");
+        memo->depth = 0;
+        walk_breadcrumb((CgreenBreadcrumb *) reporter->breadcrumb, &show_breadcrumb, memo);
+        memo->printer("\n\t");
+        // Simplify *printf statements for more robust cross-platform logging
+        if (message == NULL) {
         vsprintf(buffer, "<FATAL: NULL for failure message>", arguments);
     } else {
         vsprintf(buffer, message, arguments);

--- a/src/win32_runner_platform.c
+++ b/src/win32_runner_platform.c
@@ -59,7 +59,7 @@ static void run_named_test_child(TestSuite *suite, const char *name, TestReporte
 
             run_named_test_child(newSuite, name, reporter);
 
-            uint32_t test_duration = cgreen_time_duration_in_milliseconds(test_starting_milliseconds,
+            reporter->duration = cgreen_time_duration_in_milliseconds(test_starting_milliseconds,
                                                                           cgreen_time_get_current_milliseconds());
 
             (*reporter->finish_suite)(reporter, newSuite->filename, newSuite->line, test_duration);
@@ -86,7 +86,7 @@ void run_specified_test_if_child(TestSuite *suite, TestReporter *reporter){
 
         run_named_test_child(suite, testName, reporter);
 
-        uint32_t test_duration = cgreen_time_duration_in_milliseconds(test_starting_milliseconds,
+        reporter->duration = cgreen_time_duration_in_milliseconds(test_starting_milliseconds,
                                                                       cgreen_time_get_current_milliseconds());
 
         reporter_finish_test(reporter, suite->filename, suite->line, NULL, test_duration);
@@ -169,7 +169,7 @@ void run_test_in_its_own_process(TestSuite *suite, CgreenTest *test, TestReporte
     dispose_environment(p_environment);
     WaitForSingleObject(piProcessInfo.hProcess,INFINITE);
 
-    uint32_t test_duration = cgreen_time_duration_in_milliseconds(test_starting_milliseconds,
+    reporter->duration = cgreen_time_duration_in_milliseconds(test_starting_milliseconds,
                                                                   cgreen_time_get_current_milliseconds());
 
     (*reporter->finish_test)(reporter, test->filename, test->line, NULL, test_duration);

--- a/tests/assertion_messages_tests.expected
+++ b/tests/assertion_messages_tests.expected
@@ -48,4 +48,5 @@ assertion_messages_tests.c: Failure: AssertionMessage -> return_value_constraint
 	Got constraint of type [return value],
 		but they are not allowed for assertions, only in mock expectations.
 
+  "AssertionMessage": 1 pass, 12 failures in 0ms.
 Completed "assertion_messages_tests": 1 pass, 12 failures in 0ms.

--- a/tests/assertion_messages_tests.expected
+++ b/tests/assertion_messages_tests.expected
@@ -48,5 +48,4 @@ assertion_messages_tests.c: Failure: AssertionMessage -> return_value_constraint
 	Got constraint of type [return value],
 		but they are not allowed for assertions, only in mock expectations.
 
-Completed "AssertionMessage": 1 pass, 12 failures in 0ms.
 Completed "assertion_messages_tests": 1 pass, 12 failures in 0ms.

--- a/tests/cdash_reporter_tests.c
+++ b/tests/cdash_reporter_tests.c
@@ -13,7 +13,6 @@ using namespace cgreen;
 #endif
 
 static const int line=666;
-static const uint32_t duration_in_milliseconds = 1;
 static char *output = NULL;
 
 static void clear_output(void)
@@ -85,7 +84,7 @@ AfterEach(CDashReporter) {
 
 Ensure(CDashReporter, will_report_nothing_for_suites) {
     reporter->start_suite(reporter, "suite_name", 2);
-    reporter->finish_suite(reporter, "filename", line, 0);
+    reporter->finish_suite(reporter, "filename", line);
 }
 
 Ensure(CDashReporter, will_report_passed_for_test_with_one_pass) {
@@ -98,7 +97,7 @@ Ensure(CDashReporter, will_report_passed_for_test_with_one_pass) {
 
     // Must indicate test case completion before calling finish_test()
     send_reporter_completion_notification(reporter);
-    reporter->finish_test(reporter, "filename", line, NULL, duration_in_milliseconds);
+    reporter->finish_test(reporter, "filename", line, NULL);
 
     assert_that(output, contains_string("<Test Status=\"passed\">"));
 }
@@ -129,7 +128,7 @@ Ensure(CDashReporter, will_report_failed_once_for_each_fail) {
     
     // Must indicate test case completion before calling finish_test()
     send_reporter_completion_notification(reporter);
-    reporter->finish_test(reporter, "filename", line, NULL, duration_in_milliseconds);
+    reporter->finish_test(reporter, "filename", line, NULL);
     assert_that(output, is_equal_to_string(""));
 }
 
@@ -138,7 +137,7 @@ Ensure(CDashReporter, will_report_non_finishing_test) {
     reporter->start_suite(reporter, "suite_name", 1);
 
     send_reporter_exception_notification(reporter);
-    reporter->finish_suite(reporter, "filename", line, duration_in_milliseconds);
+    reporter->finish_suite(reporter, "filename", line);
 
     assert_that(output, contains_string("<Test Status=\"incomplete\">"));
 }

--- a/tests/constraint_messages_tests.expected
+++ b/tests/constraint_messages_tests.expected
@@ -157,4 +157,5 @@ constraint_messages_tests.c: Exception: ConstraintMessage -> increments_exceptio
 constraint_messages_tests.c: Exception: ConstraintMessage -> increments_exception_count_when_terminating_via_SIGTERM 
 	Test terminated with signal: Terminated
 
+  "ConstraintMessage": 35 failures, 2 exceptions in 0ms.
 Completed "constraint_messages_tests": 35 failures, 2 exceptions in 0ms.

--- a/tests/constraint_messages_tests.expected
+++ b/tests/constraint_messages_tests.expected
@@ -157,5 +157,4 @@ constraint_messages_tests.c: Exception: ConstraintMessage -> increments_exceptio
 constraint_messages_tests.c: Exception: ConstraintMessage -> increments_exception_count_when_terminating_via_SIGTERM 
 	Test terminated with signal: Terminated
 
-Completed "ConstraintMessage": 35 failures, 2 exceptions in 0ms.
 Completed "constraint_messages_tests": 35 failures, 2 exceptions in 0ms.

--- a/tests/cute_reporter_tests.c
+++ b/tests/cute_reporter_tests.c
@@ -15,7 +15,6 @@ using namespace cgreen;
 #endif
 
 static const int line=666;
-static const uint32_t duration_in_milliseconds = 1;
 static char *output = NULL;
 
 static void clear_output(void)
@@ -104,7 +103,7 @@ Ensure(CuteReporter, will_report_beginning_and_successful_finishing_of_test) {
 
     // Must indicate test case completion before calling finish_test()
     send_reporter_completion_notification(reporter);
-    reporter->finish_test(reporter, "filename", line, NULL, duration_in_milliseconds);
+    reporter->finish_test(reporter, "filename", line, NULL);
     assert_that(output, begins_with_string("#success"));
     assert_that(output, contains_string("test_name"));
 }
@@ -128,7 +127,7 @@ Ensure(CuteReporter, will_report_failing_of_test_only_once) {
 
     // Must indicate test case completion before calling finish_test()
     send_reporter_completion_notification(reporter);
-    reporter->finish_test(reporter, "filename", line, NULL, duration_in_milliseconds);
+    reporter->finish_test(reporter, "filename", line, NULL);
     assert_no_output();
 }
 
@@ -139,7 +138,7 @@ Ensure(CuteReporter, will_report_finishing_of_suite) {
     clear_output();
     
     send_reporter_completion_notification(reporter);
-    reporter->finish_suite(reporter, "filename", line, duration_in_milliseconds);
+    reporter->finish_suite(reporter, "filename", line);
 
     assert_that(output, begins_with_string("#ending"));
     assert_that(output, contains_string("suite_name"));
@@ -151,7 +150,7 @@ Ensure(CuteReporter, will_report_non_finishing_test) {
     clear_output();
 
     send_reporter_exception_notification(reporter);
-    reporter->finish_suite(reporter, "filename", line, duration_in_milliseconds);
+    reporter->finish_suite(reporter, "filename", line);
 
     assert_that(output, begins_with_string("#error"));
     assert_that(output, contains_string("failed to complete"));

--- a/tests/failure_messages_tests.expected
+++ b/tests/failure_messages_tests.expected
@@ -5,4 +5,5 @@ failure_messages_tests.c: Exception: FailureMessage -> for_CGREEN_PER_TEST_TIMEO
 failure_messages_tests.c: Exception: FailureMessage -> for_time_out_in_only_one_second 
 	Test terminated unexpectedly, likely from a non-standard exception or Posix signal
 
+  "FailureMessage": 1 pass, 2 exceptions in 0ms.
 Completed "failure_messages_tests": 1 pass, 2 exceptions in 0ms.

--- a/tests/failure_messages_tests.expected
+++ b/tests/failure_messages_tests.expected
@@ -5,5 +5,4 @@ failure_messages_tests.c: Exception: FailureMessage -> for_CGREEN_PER_TEST_TIMEO
 failure_messages_tests.c: Exception: FailureMessage -> for_time_out_in_only_one_second 
 	Test terminated unexpectedly, likely from a non-standard exception or Posix signal
 
-Completed "FailureMessage": 1 pass, 2 exceptions in 0ms.
 Completed "failure_messages_tests": 1 pass, 2 exceptions in 0ms.

--- a/tests/ignore_messages_tests.expected
+++ b/tests/ignore_messages_tests.expected
@@ -5,4 +5,5 @@ ignore_messages_tests.c: Exception: IgnoreMessage -> should_not_count_exceptions
 ignore_messages_tests.c: Failure: IgnoreMessage -> should_not_count_failing_tests_as_ignored 
 	Expected [0] to [be true]
 
+  "IgnoreMessage": 1 pass, 1 skipped, 1 failure, 1 exception in 0ms.
 Completed "ignore_messages_tests": 1 pass, 1 skipped, 1 failure, 1 exception in 0ms.

--- a/tests/ignore_messages_tests.expected
+++ b/tests/ignore_messages_tests.expected
@@ -5,5 +5,4 @@ ignore_messages_tests.c: Exception: IgnoreMessage -> should_not_count_exceptions
 ignore_messages_tests.c: Failure: IgnoreMessage -> should_not_count_failing_tests_as_ignored 
 	Expected [0] to [be true]
 
-Completed "IgnoreMessage": 1 pass, 1 skipped, 1 failure, 1 exception in 0ms.
 Completed "ignore_messages_tests": 1 pass, 1 skipped, 1 failure, 1 exception in 0ms.

--- a/tests/mock_messages_tests.expected
+++ b/tests/mock_messages_tests.expected
@@ -28,6 +28,7 @@ mock_messages_tests.c: Failure: Mocks -> reports_multiple_never_expect
 mock_messages_tests.c: Failure: Mocks -> single_uncalled_expectation_fails_tally 
 	Expected call was not made to mocked function [string_out]
 
+  "Mocks": 4 passes, 2 skipped, 9 failures in 0ms.
 Completed "mock_messages_tests": 4 passes, 2 skipped, 9 failures in 0ms.
 Mocks -> learning_mocks_emit_none_when_learning_no_mocks : Learned mocks are
 	<none>

--- a/tests/mock_messages_tests.expected
+++ b/tests/mock_messages_tests.expected
@@ -28,7 +28,6 @@ mock_messages_tests.c: Failure: Mocks -> reports_multiple_never_expect
 mock_messages_tests.c: Failure: Mocks -> single_uncalled_expectation_fails_tally 
 	Expected call was not made to mocked function [string_out]
 
-Completed "Mocks": 4 passes, 2 skipped, 9 failures in 0ms.
 Completed "mock_messages_tests": 4 passes, 2 skipped, 9 failures in 0ms.
 Mocks -> learning_mocks_emit_none_when_learning_no_mocks : Learned mocks are
 	<none>

--- a/tests/text_reporter_tests.c
+++ b/tests/text_reporter_tests.c
@@ -16,7 +16,6 @@ using namespace cgreen;
 
 
 static const int line=666;
-static const uint32_t duration_in_milliseconds = 1;
 static char *output = NULL;
 
 static void clear_output(void)
@@ -87,7 +86,7 @@ AfterEach(TextReporter) {
 
 Ensure(TextReporter, will_report_beginning_and_end_of_suites) {
     reporter->start_suite(reporter, "suite_name", 2);
-    reporter->finish_suite(reporter, "filename", line, 0);
+    reporter->finish_suite(reporter, "filename", line);
     assert_that(output, begins_with_string("Running \"suite_name\" (2 tests)"));
     assert_that(output, contains_string("Completed \"suite_name\""));
 }
@@ -101,8 +100,8 @@ Ensure(TextReporter, will_report_passed_for_test_with_one_pass_on_completion) {
 
     // Must indicate test case completion before calling finish_test()
     send_reporter_completion_notification(reporter);
-    reporter->finish_test(reporter, "filename", line, NULL, duration_in_milliseconds);
-    reporter->finish_suite(reporter, "filename", line, duration_in_milliseconds);
+    reporter->finish_test(reporter, "filename", line, NULL);
+    reporter->finish_suite(reporter, "filename", line);
 
     assert_that(output, contains_string("Completed \"suite_name\": 1 pass"));
 }
@@ -127,7 +126,7 @@ Ensure(TextReporter, will_report_failed_once_for_each_fail) {
     
     // Must indicate test case completion before calling finish_test()
     send_reporter_completion_notification(reporter);
-    reporter->finish_test(reporter, "filename", line, NULL, duration_in_milliseconds);
+    reporter->finish_test(reporter, "filename", line, NULL);
     assert_that(output, is_equal_to_string(""));
 }
 
@@ -137,7 +136,7 @@ Ensure(TextReporter, will_report_non_finishing_test) {
     reporter->start_suite(reporter, "suite_name", 1);
 
     send_reporter_exception_notification(reporter);
-    reporter->finish_suite(reporter, "filename", line, duration_in_milliseconds);
+    reporter->finish_suite(reporter, "filename", line);
 
     assert_that(output, contains_string("1 exception"));
 }

--- a/tests/xml_reporter_tests.c
+++ b/tests/xml_reporter_tests.c
@@ -15,7 +15,6 @@ using namespace cgreen;
 
 
 static const int line=666;
-static const uint32_t duration_in_milliseconds = 1;
 static char *output = NULL;
 
 static void clear_output(void)
@@ -102,7 +101,7 @@ Ensure(XmlReporter, will_report_beginning_and_successful_finishing_of_passing_te
     reporter->show_pass(reporter, "file", 2, "test_name", null_arguments);
     assert_that(strlen(output), is_equal_to(0));
 
-    reporter->finish_test(reporter, "filename", line, NULL, duration_in_milliseconds);
+    reporter->finish_test(reporter, "filename", line, NULL);
     assert_that(output, contains_string("</testcase>"));
 }
 
@@ -113,7 +112,7 @@ Ensure(XmlReporter, will_report_a_failing_test) {
 
     reporter->start_test(reporter, "test_name");
     reporter->show_fail(reporter, "file", 2, "test_name", null_arguments);
-    reporter->finish_test(reporter, "filename", line, NULL, duration_in_milliseconds);
+    reporter->finish_test(reporter, "filename", line, NULL);
     
     assert_that(output, contains_string("<failure message=\"test_name\">"));
     assert_that(output, contains_string("<location file=\"file\" line=\"2\"/>"));
@@ -123,7 +122,7 @@ Ensure(XmlReporter, will_report_a_failing_test) {
 
 Ensure(XmlReporter, will_report_finishing_of_suite) {
     reporter->start_suite(reporter, "suite_name", 1);
-    reporter->finish_suite(reporter, "filename", line, duration_in_milliseconds);
+    reporter->finish_suite(reporter, "filename", line);
 
     assert_that(output, contains_string("</testsuite>"));
 }
@@ -135,8 +134,8 @@ Ensure(XmlReporter, will_mark_ignored_test_as_skipped) {
     reporter->start_suite(reporter, "suite_name", 1);
     reporter->start_test(reporter, "skipped_test_name");
     send_reporter_skipped_notification(reporter);
-    reporter->finish_test(reporter, "filename", line, "message", duration_in_milliseconds);
-    reporter->finish_suite(reporter, "filename", line, duration_in_milliseconds);
+    reporter->finish_test(reporter, "filename", line, "message");
+    reporter->finish_suite(reporter, "filename", line);
 
     assert_that(output, contains_string("<skipped />"));
     assert_that(strstr(output, "time="), is_less_than(strstr(output, "<skipped")));
@@ -149,8 +148,8 @@ Ensure(XmlReporter, will_report_non_finishing_test) {
     reporter->start_suite(reporter, "suite_name", 1);
     reporter->start_test(reporter, "test_name");
     send_reporter_exception_notification(reporter);
-    reporter->finish_test(reporter, "filename", line, "message", duration_in_milliseconds);
-    reporter->finish_suite(reporter, "filename", line, duration_in_milliseconds);
+    reporter->finish_test(reporter, "filename", line, "message");
+    reporter->finish_suite(reporter, "filename", line);
 
     assert_that(output, contains_string("error type=\"Fatal\""));
     assert_that(output, contains_string("message=\"message\""));


### PR DESCRIPTION
Prior to this change, if one create a top-level suite called Suite_A, and in
that suite added 2 sub-suites, subsuite_1 and subsuite_2 which had 2 tests and
4 asserts each, the output would be:

Running "Suite_A" (4 tests):
Completed "subsuite_1": 4 passes in Xms.
Completed "subsuite_2": 8 passes in Yms.
Completed "Suite_A": 8 passes in Zms.

This is misleading if you don't realize the count is cumulative.  Since the
"Running" message only occurs for the top-level suite, it makes sense for
the summary to only report for the top-level suite, and is less confusing.
The new output is:

Running "Suite_A" (4 tests):
Completed "Suite_A": 8 passes in Zms.