### PR TITLE
failure_message_for memory leak patch

### DIFF
--- a/src/message_formatting.c
+++ b/src/message_formatting.c
@@ -208,6 +208,8 @@ char *failure_message_for(Constraint *constraint, const char *actual_string, int
              actual_value_as_string,
              constraint->name);
 
+    free((void*)actual_value_as_string);
+
     if (no_expected_value_in(constraint)) {
         return message;
     } else


### PR DESCRIPTION
Prior to this commit there was an allocated string that
was not freed after it was used. This resulted in memory
leaks that caused Valgrind tests in applications that use
libcgreen.so to fail. After this commit those tests succeed.

There are a few other leaks reported by Valgrind but this fix
remedies 202 leaks reported by the following command
`valgrind --leak-check=yes test_cgreen_c`.