### PR TITLE
Use running totals to detect failures in the test runner.

### DIFF
--- a/src/runner.c
+++ b/src/runner.c
@@ -37,7 +37,7 @@ int run_test_suite(TestSuite *suite, TestReporter *reporter) {
 
     setup_reporting(reporter);
     run_every_test(suite, reporter);
-    success = (reporter->failures == 0) && (reporter->exceptions==0);
+    success = (reporter->total_failures == 0) && (reporter->total_exceptions==0);
     return success ? EXIT_SUCCESS : EXIT_FAILURE;
 }
 
@@ -49,7 +49,7 @@ int run_single_test(TestSuite *suite, const char *name, TestReporter *reporter) 
 
     setup_reporting(reporter);
     run_named_test(suite, name, reporter);
-    success = (reporter->failures == 0);
+    success = (reporter->total_failures == 0);
     return success ? EXIT_SUCCESS : EXIT_FAILURE;
 }
 
@@ -259,7 +259,7 @@ static void run_teardown_for(CgreenTest *spec) {
 
 /**
    run()
-   
+
    N.B. Although this is neither an API or public function, it is
    documented as a good place to put a breakpoint. Do not change the
    name or semantics of this function, it should continue to be very


### PR DESCRIPTION
When the test reporting was updated to make sub-suite reports independent,
rather than running totals, a bug was introduced whereby the runner would
only look at the top-level suite results to indicate success or failure,
rather than the running totals.  This patch addresses that bug.