### PR TITLE
Double comparison corrections

### DIFF
--- a/doc/cgreen-guide-en.asciidoc
+++ b/doc/cgreen-guide-en.asciidoc
@@ -1671,6 +1671,9 @@ same as for the assertions we saw earlier):
 For the double valued constraints you can set the number of
 significant digits to consider a match with a call to
 `significant_figures_for_assert_double_are(int figures)`.
+The <<floating_point_comparison_algorithm,
+section on how to work with doubles>> has a more detailed
+discussion of the algorithm used for comparing floating point numbers.
 
 Then there are two ways to return results:
 
@@ -1984,6 +1987,33 @@ Here's an example of that:
 include::tutorial_src/double_tests1.c[lines=16..26]
 -----------------------------
 
+
+[[floating_point_comparison_algorithm]]
+==== Details of floating point comparison algorithm
+
+The number of significant digits set with
+`significant_figures_for_assert_double_are` specifies a _relative_ tolerance.
+Cgreen considers two double precision numbers +x+ and +y+ equal if their
+difference normalized by the larger of the two is smaller than +10^(1 -
+significant_figures)^+. Mathematically, we check that
++|x - y| < max(|x|, |y|) * 10^(1 - significant_figures)^+.
+
+Well documented subtleties arise when comparing floating point numbers close to
+zero using this algorithm. The article
+https://randomascii.wordpress.com/2012/02/25/comparing-floating-point-numbers-2012-edition/[Comparing Floating Point Numbers, 2012 Edition]
+by Bruce Dawson has an excellent discussion of the issue. The essence of the
+problem can be appreciated if we consider the special case where +y == 0+. In
+that case, our condition reduces to +|x| < |x| * 10^(1 - significant_figures)^+.
+After cancelling +|x|+ this simplifies to +1 < 10^(1 - significant_figures)^+.
+But this is only true if +significant_figures < 1+. In words this can be
+summarized by saying that, in a relative sense, _all_ numbers are very different
+from zero. To circumvent this difficulty we recommend to use a constraint of the
+following form when comparing numbers close to zero:
+
+[source,c]
+-----------------------
+assert_that(fabs(x - y) < abs_tolerance);
+-----------------------
 
 
 === Using Cgreen with C{pp}

--- a/src/constraint.c
+++ b/src/constraint.c
@@ -5,6 +5,7 @@
 #include <cgreen/string_comparison.h>
 #include <cgreen/vector.h>
 #include <inttypes.h>
+#include <float.h>
 #include <limits.h>
 #include <math.h>
 #ifndef __cplusplus
@@ -42,6 +43,7 @@
 
 
 static int significant_figures = 8;
+static double absolute_tolerance = DBL_MIN / 1.0e-8;
 
 
 static double accuracy(int significant_figures, double largest);
@@ -696,7 +698,9 @@ bool constraint_is_for_parameter_in(const Constraint *constraint, const char *na
 }
 
 bool doubles_are_equal(double tried, double expected) {
-    return max(tried, expected) - min(tried, expected) < accuracy(significant_figures, max(fabs(tried), fabs(expected)));
+    double abs_diff = fabs(tried - expected);
+    if (abs_diff < absolute_tolerance) return true;
+    return abs_diff < accuracy(significant_figures, max(fabs(tried), fabs(expected)));
 }
 
 bool double_is_lesser(double actual, double expected) {
@@ -708,7 +712,7 @@ bool double_is_greater(double actual, double expected) {
 }
 
 static double accuracy(int figures, double largest) {
-    return pow(10, 1 + (int)log10(fabs(largest)) - figures);
+    return pow(10.0, 1.0 + floor(log10(fabs(largest))) - figures);
 }
 
 void significant_figures_for_assert_double_are(int figures) {

--- a/tests/double_tests.c
+++ b/tests/double_tests.c
@@ -12,3 +12,13 @@ Ensure(Double, comparison_with_negative_values_should_not_always_succeed) {
     /*  Issue #146 - Fixed */
     assert_that_double(-500, is_not_equal_to_double(0));
 }
+
+xEnsure(Double, relative_epsilon_calculations_with_0_and_a_very_small_number_should_not_fail) {
+    /* Issue #147 */
+    assert_that_double(0.000000000000001, is_equal_to_double(0));
+}
+
+xEnsure(Double, comparisons_with_extremely_small_numbers_should_not_always_fail) {
+    /*  Issue #149 */
+    assert_that_double(4.9406564584124654E-324, is_equal_to_double(4.9406564584124654E-324));
+}

--- a/tests/double_tests.c
+++ b/tests/double_tests.c
@@ -13,12 +13,12 @@ Ensure(Double, comparison_with_negative_values_should_not_always_succeed) {
     assert_that_double(-500, is_not_equal_to_double(0));
 }
 
-xEnsure(Double, relative_epsilon_calculations_with_0_and_a_very_small_number_should_not_fail) {
-    /* Issue #147 */
-    assert_that_double(0.000000000000001, is_equal_to_double(0));
-}
-
-xEnsure(Double, comparisons_with_extremely_small_numbers_should_not_always_fail) {
+Ensure(Double, comparisons_with_extremely_small_numbers_should_not_always_fail) {
     /*  Issue #149 */
     assert_that_double(4.9406564584124654E-324, is_equal_to_double(4.9406564584124654E-324));
+}
+
+Ensure(Double, numbers_within_absolute_tolerance_of_zero_are_considered_equal_to_zero) {
+    double my_dbl_min = 2.2250738585072014e-308;
+    assert_that_double(1.0e4 * my_dbl_min, is_equal_to_double(0.0));
 }


### PR DESCRIPTION
This fixes #148 and fixes #149. It does _not_ address #147.

In my opinion, given the way double comparison currently works in cgreen, #147 is expected behavior. `significant_figures` always indicates a relative precision, never an absolute tolerance. Perhaps #147 should be a feature request for an absolute tolerance. But this would be in addition to `significant_figures`. One way to add this capability is by introducing something like `doubles_are_close(double tried, double expected, double epsilon)`. This is what gtest and the boost unit test framework do. Or there could be a `absolute_tolerance_for_assert_double_is` function which sets a cgreen static variable analogous to `significant_figures_for_assert_double_are`.

The absolute tolerance introduced in this patch leads to a (cosmetic?) issue. An assertion like `assert_that_double(x, is_not_equal_to_double(0))` can fail because `x` was within the absolute tolerance of 0. But our error message suggests that the assertion fails because `x` is within the relative epsilon of 0. I don't know of a good way to fix this. If we think this is important enough I can create an issue with a test case and more in-depth discussion.