### PR TITLE
Add side effect constraint

### DIFF
--- a/doc/cgreen-guide-en.asciidoc
+++ b/doc/cgreen-guide-en.asciidoc
@@ -1589,6 +1589,18 @@ other way, from code to stub. This gets us into the same territory as
 mock objects.
 
 
+=== Executing function as a side effect
+
+There are time where we want to execute a function whenever a mock is
+invoked. One example of these cases is we want to call another diagnose
+function.
+
+[source, c]
+-----------------------
+include::tutorial_src/stream_test.c[lines=96..112]
+-----------------------
+
+
 === Setting Expectations on Mock Functions
 
 To swap the traffic flow, we'll look at an outgoing example instead.
@@ -1713,6 +1725,7 @@ Then there are two ways to return results:
 |`will_return(value)`                                         |Return the value from the mock function (which needs to be declared returning that type
 |`will_return_double(value)`                                  |Ditto for double values (required because of C's type coercion rules which would otherwise convert a double into an int)
 |`will_set_contents_of_parameter(parameter_name, value, size)`|Writes the value in the referenced parameter
+|`with_sideeffect(pointer_to_function, pointer_to_data)`      |Executes the side effect function and passes data to it
 |===========================================================================================
 
 You can combine these in various ways:
@@ -1725,6 +1738,7 @@ You can combine these in various ways:
   expect(mocked_file_reader,
         when(file, is_equal_to_contents_of(&FD, sizeof(FD))),
         when(input, is_equal_to_string("Hello world!"),
+        with_sideeffect(&update_counter, &counter),
         will_set_contents_of_parameter(status, FD_CLOSED, sizeof(bool))));
 -----------------------
 

--- a/doc/cgreen-guide-en.asciidoc
+++ b/doc/cgreen-guide-en.asciidoc
@@ -1725,8 +1725,10 @@ Then there are two ways to return results:
 |`will_return(value)`                                         |Return the value from the mock function (which needs to be declared returning that type
 |`will_return_double(value)`                                  |Ditto for double values (required because of C's type coercion rules which would otherwise convert a double into an int)
 |`will_set_contents_of_parameter(parameter_name, value, size)`|Writes the value in the referenced parameter
-|`with_sideeffect(pointer_to_function, pointer_to_data)`      |Executes the side effect function and passes data to it
+|`with_side_effect(pointer_to_function, pointer_to_data)`     |Executes the side effect function and passes data to it
 |===========================================================================================
+
+Note: The `pointer_to_data` passed to `with_side_effect` need to fit inside a `intptr_t`
 
 You can combine these in various ways:
 
@@ -1738,7 +1740,7 @@ You can combine these in various ways:
   expect(mocked_file_reader,
         when(file, is_equal_to_contents_of(&FD, sizeof(FD))),
         when(input, is_equal_to_string("Hello world!"),
-        with_sideeffect(&update_counter, &counter),
+        with_side_effect(&update_counter, &counter),
         will_set_contents_of_parameter(status, FD_CLOSED, sizeof(bool))));
 -----------------------
 

--- a/doc/tutorial_src/stream_test.c
+++ b/doc/tutorial_src/stream_test.c
@@ -94,6 +94,23 @@ Ensure(empty_paragraphs_are_ignored) {
     by_paragraph(&reader, NULL, &writer, NULL);
 }
 
+static void update_counter(void * counter) {
+    *counter = *counter + 1;
+}
+
+Ensure(using_side_effect) {
+    int number_of_times_reader_was_called = 0;
+    expect(reader, will_return('\n'));
+    always_expect(reader,
+                  will_return(EOF),
+                  with_sideeffect(&update_counter,
+                                  &number_of_times_reader_was_called));
+    expect_never(writer);
+    by_paragraph(&reader, NULL, &writer, NULL);
+
+    assert_that(number_of_times_reader_was_called, is_equal_to(1));
+}
+
 int main(int argc, char **argv) {
     TestSuite *suite = create_test_suite();
     add_test(suite, reading_lines_from_empty_stream_gives_null);

--- a/doc/tutorial_src/stream_test.c
+++ b/doc/tutorial_src/stream_test.c
@@ -103,7 +103,7 @@ Ensure(using_side_effect) {
     expect(reader, will_return('\n'));
     always_expect(reader,
                   will_return(EOF),
-                  with_sideeffect(&update_counter,
+                  with_side_effect(&update_counter,
                                   &number_of_times_reader_was_called));
     expect_never(writer);
     by_paragraph(&reader, NULL, &writer, NULL);

--- a/include/cgreen/constraint.h
+++ b/include/cgreen/constraint.h
@@ -34,8 +34,8 @@ struct Constraint_ {
     const char *expected_value_name;
 
     /* Side Effect parameters */ 
-    void (*sideeffect_callback)(void *);
-    void *sideeffect_data;
+    void (*side_effect_callback)(void *);
+    void *side_effect_data;
 
     /* for PARAMETER constraints */
     const char *parameter_name;
@@ -79,7 +79,7 @@ Constraint *create_greater_than_double_constraint(double expected_value, const c
 Constraint *create_return_value_constraint(intptr_t value_to_return);
 Constraint *create_return_double_value_constraint(double value_to_return);
 Constraint *create_set_parameter_value_constraint(const char *parameter_name, intptr_t value_to_set, size_t size_to_set);
-Constraint *create_with_sideeffect_constraint(void (*callback)(void *), void *data);
+Constraint *create_with_side_effect_constraint(void (*callback)(void *), void *data);
 
 #ifdef __cplusplus
     }

--- a/include/cgreen/constraint.h
+++ b/include/cgreen/constraint.h
@@ -33,6 +33,10 @@ struct Constraint_ {
     CgreenValue expected_value;
     const char *expected_value_name;
 
+    /* Side Effect parameters */ 
+    void (*sideeffect_callback)(void *);
+    void *sideeffect_data;
+
     /* for PARAMETER constraints */
     const char *parameter_name;
     size_t size_of_expected_value;
@@ -75,6 +79,7 @@ Constraint *create_greater_than_double_constraint(double expected_value, const c
 Constraint *create_return_value_constraint(intptr_t value_to_return);
 Constraint *create_return_double_value_constraint(double value_to_return);
 Constraint *create_set_parameter_value_constraint(const char *parameter_name, intptr_t value_to_set, size_t size_to_set);
+Constraint *create_with_sideeffect_constraint(void (*callback)(void *), void *data);
 
 #ifdef __cplusplus
     }

--- a/include/cgreen/constraint_syntax_helpers.h
+++ b/include/cgreen/constraint_syntax_helpers.h
@@ -41,7 +41,7 @@
 #define is_greater_than_double(value) create_greater_than_double_constraint(value, #value)
 
 
-#define with_sideeffect(callback, data) create_with_sideeffect_constraint(callback, data)
+#define with_side_effect(callback, data) create_with_side_effect_constraint(callback, data)
 #define will_return(value) create_return_value_constraint((intptr_t)value)
 #define will_return_double(value) create_return_double_value_constraint(value)
 #define will_set_contents_of_parameter(parameter_name, value, size) create_set_parameter_value_constraint(#parameter_name, (intptr_t)value, (size_t)size)

--- a/include/cgreen/constraint_syntax_helpers.h
+++ b/include/cgreen/constraint_syntax_helpers.h
@@ -41,6 +41,7 @@
 #define is_greater_than_double(value) create_greater_than_double_constraint(value, #value)
 
 
+#define with_sideeffect(callback, data) create_with_sideeffect_constraint(callback, data)
 #define will_return(value) create_return_value_constraint((intptr_t)value)
 #define will_return_double(value) create_return_double_value_constraint(value)
 #define will_set_contents_of_parameter(parameter_name, value, size) create_set_parameter_value_constraint(#parameter_name, (intptr_t)value, (size_t)size)

--- a/src/constraint.c
+++ b/src/constraint.c
@@ -431,13 +431,13 @@ Constraint *create_set_parameter_value_constraint(const char *parameter_name, in
     return constraint;
 }
 
-Constraint *create_with_sideeffect_constraint(void (*callback)(void *), void *data) {
+Constraint *create_with_side_effect_constraint(void (*callback)(void *), void *data) {
     Constraint* constraint = create_constraint();
     constraint->type = CALL;
 
     constraint->name = "cause side effect";
-    constraint->sideeffect_callback = callback;
-    constraint->sideeffect_data = data;
+    constraint->side_effect_callback = callback;
+    constraint->side_effect_data = data;
 	constraint->execute = &execute_sideeffect;
 	
 	return constraint;
@@ -508,7 +508,7 @@ static void execute_sideeffect(Constraint *constraint, const char *function, Cgr
 	(void)function;
 	(void)actual;
 	
-	if (constraint->sideeffect_callback == NULL) {
+	if (constraint->side_effect_callback == NULL) {
 		
 		(*reporter->assert_true)(
 			reporter,
@@ -517,7 +517,7 @@ static void execute_sideeffect(Constraint *constraint, const char *function, Cgr
 			false,
 			"no side effect function was set");
 	}
-	(constraint->sideeffect_callback)(constraint->sideeffect_data);
+	(constraint->side_effect_callback)(constraint->side_effect_data);
 }
 
 

--- a/src/constraint_syntax_helpers.c
+++ b/src/constraint_syntax_helpers.c
@@ -17,6 +17,8 @@ Constraint static_is_non_null_constraint = {
     /* .expected_value_message */ "",
     /* .expected_value */ {INTEGER, {0}},
     /* .stored_value_name */ "null",
+    /* .sideeffect_callback */ NULL,
+    /* .sideeffect_data */ NULL,
     /* .parameter_name */ NULL,
     /* .size_of_stored_value */ 0
 };
@@ -32,6 +34,8 @@ Constraint static_is_null_constraint = {
     /* .expected_value_message */ "",
     /* .expected_value */ {INTEGER, {(intptr_t)NULL}},
     /* .stored_value_name */ "null",
+    /* .sideeffect_callback */ NULL,
+    /* .sideeffect_data */ NULL,
     /* .parameter_name */ NULL,
     /* .size_of_stored_value */ 0
 };
@@ -47,6 +51,8 @@ Constraint static_is_false_constraint = {
     /* .expected_value_message */ "",
     /* .expected_value */ {INTEGER, {false}},
     /* .stored_value_name */ "false",
+    /* .sideeffect_callback */ NULL,
+    /* .sideeffect_data */ NULL,
     /* .parameter_name */ NULL,
     /* .size_of_stored_value */ 0
 };
@@ -62,6 +68,8 @@ Constraint static_is_true_constraint = {
     /* .expected_message */ "",
     /* .expected_value */ {INTEGER, {true}},
     /* .stored_value_name */ "true",
+    /* .sideeffect_callback */ NULL,
+    /* .sideeffect_data */ NULL,
     /* .parameter_name */ NULL,
     /* .size_of_stored_value */ 0
 };

--- a/src/constraint_syntax_helpers.c
+++ b/src/constraint_syntax_helpers.c
@@ -17,8 +17,8 @@ Constraint static_is_non_null_constraint = {
     /* .expected_value_message */ "",
     /* .expected_value */ {INTEGER, {0}},
     /* .stored_value_name */ "null",
-    /* .sideeffect_callback */ NULL,
-    /* .sideeffect_data */ NULL,
+    /* .side_effect_callback */ NULL,
+    /* .side_effect_data */ NULL,
     /* .parameter_name */ NULL,
     /* .size_of_stored_value */ 0
 };
@@ -34,8 +34,8 @@ Constraint static_is_null_constraint = {
     /* .expected_value_message */ "",
     /* .expected_value */ {INTEGER, {(intptr_t)NULL}},
     /* .stored_value_name */ "null",
-    /* .sideeffect_callback */ NULL,
-    /* .sideeffect_data */ NULL,
+    /* .side_effect_callback */ NULL,
+    /* .side_effect_data */ NULL,
     /* .parameter_name */ NULL,
     /* .size_of_stored_value */ 0
 };
@@ -51,8 +51,8 @@ Constraint static_is_false_constraint = {
     /* .expected_value_message */ "",
     /* .expected_value */ {INTEGER, {false}},
     /* .stored_value_name */ "false",
-    /* .sideeffect_callback */ NULL,
-    /* .sideeffect_data */ NULL,
+    /* .side_effect_callback */ NULL,
+    /* .side_effect_data */ NULL,
     /* .parameter_name */ NULL,
     /* .size_of_stored_value */ 0
 };
@@ -68,8 +68,8 @@ Constraint static_is_true_constraint = {
     /* .expected_message */ "",
     /* .expected_value */ {INTEGER, {true}},
     /* .stored_value_name */ "true",
-    /* .sideeffect_callback */ NULL,
-    /* .sideeffect_data */ NULL,
+    /* .side_effect_callback */ NULL,
+    /* .side_effect_data */ NULL,
     /* .parameter_name */ NULL,
     /* .size_of_stored_value */ 0
 };

--- a/src/mocks.c
+++ b/src/mocks.c
@@ -79,12 +79,10 @@ static void report_mock_parameter_name_not_found(TestReporter *test_reporter,
                                                  const char *parameter);
 static void destroy_expectation_if_time_to_die(RecordedExpectation *expectation);
 
-static bool
-is_sideeffect_constraint(const Constraint *constraint);
-static void
-apply_sideeffect(TestReporter *test_reporter,
-                 const RecordedExpectation *expectation,
-                 Constraint *constraint);
+static bool is_side_effect_constraint(const Constraint *constraint);
+static void apply_side_effect(TestReporter *test_reporter,
+                              const RecordedExpectation *expectation,
+                              Constraint *constraint);
 
 void cgreen_mocks_are(CgreenMockMode mock_mode) {
     cgreen_mocks_are_ = mock_mode;
@@ -227,8 +225,8 @@ intptr_t mock_(TestReporter* test_reporter, const char *function, const char *mo
     for (i = 0; i < cgreen_vector_size(expectation->constraints); i++) {
         Constraint *constraint = (Constraint *)cgreen_vector_get(expectation->constraints, i);
 
-        if (is_sideeffect_constraint(constraint)) {
-            apply_sideeffect(test_reporter, expectation, constraint);
+        if (is_side_effect_constraint(constraint)) {
+            apply_side_effect(test_reporter, expectation, constraint);
             continue;
         }
 
@@ -314,13 +312,11 @@ intptr_t mock_(TestReporter* test_reporter, const char *function, const char *mo
         return stored_result.value.integer_value;
 }
 
-static
-void
-apply_sideeffect(TestReporter *test_reporter,
-                 const RecordedExpectation *expectation,
-                 Constraint *constraint)
+static void apply_side_effect(TestReporter *test_reporter,
+                  const RecordedExpectation *expectation,
+                  Constraint *constraint)
 {
-    CgreenValue actual;
+    CgreenValue actual = {};
     constraint->execute(
                     constraint,
                     expectation->function,
@@ -331,7 +327,7 @@ apply_sideeffect(TestReporter *test_reporter,
 }
 static
 bool
-is_sideeffect_constraint(const Constraint *constraint) { return constraint->type == CALL; }
+is_side_effect_constraint(const Constraint *constraint) { return constraint->type == CALL; }
 
 static CgreenVector *create_vector_of_actuals(va_list actuals, int count) {
     int i;

--- a/tests/message_formatting_tests.c
+++ b/tests/message_formatting_tests.c
@@ -1,6 +1,7 @@
 #include <cgreen/cgreen.h>
 #include <cgreen/message_formatting.h>
 #include <stdlib.h>
+#include "src/constraint_internal.h"
 
 #ifdef __cplusplus
 using namespace cgreen;
@@ -22,6 +23,7 @@ Ensure(MessageFormatting, can_show_failure_message_containing_percent_sign) {
 
     constraint->destroy(constraint);
     free(failure_message);
+    destroy_constraint(constraint);
 }
 
 Ensure(MessageFormatting, shows_offset_as_zero_based) {
@@ -42,6 +44,7 @@ Ensure(MessageFormatting, shows_offset_as_zero_based) {
 
     constraint->destroy(constraint);
     free(failure_message);
+    destroy_constraint(constraint);
 }
 
 TestSuite *message_formatting_tests(void) {

--- a/tests/mocks_tests.c
+++ b/tests/mocks_tests.c
@@ -380,6 +380,26 @@ Ensure(Mocks, constraint_number_of_calls_order_of_expectations_matter) {
     simple_mocked_function(1, 2);
 }
 
+static int sideeffect_changed = 1;
+static int mock_with_sideeffect(void) {
+    return (int)mock();
+}
+static void the_sideeffect(void * data) {
+	assert_that(*(int*)data, is_equal_to(99));
+    sideeffect_changed = 2;
+}
+
+Ensure(Mocks, mock_expect_with_sideeffect) {
+	int data_passed_to_sideeffect = 99;
+    expect(mock_with_sideeffect,
+           with_sideeffect(&the_sideeffect, &data_passed_to_sideeffect),
+           will_return(22));
+
+    assert_that(mock_with_sideeffect(), is_equal_to(22));
+
+    assert_that(sideeffect_changed, is_equal_to(2));
+}
+
 
 TestSuite *mock_tests(void) {
     TestSuite *suite = create_test_suite();
@@ -413,6 +433,7 @@ TestSuite *mock_tests(void) {
     add_test_with_context(suite, Mocks, constraint_number_of_calls_when_is_present);
     add_test_with_context(suite, Mocks, constraint_number_of_calls_when_multiple_expectations_are_present);
     add_test_with_context(suite, Mocks, constraint_number_of_calls_order_of_expectations_matter);
+    add_test_with_context(suite, Mocks, mock_expect_with_sideeffect);
 
     return suite;
 }

--- a/tests/mocks_tests.c
+++ b/tests/mocks_tests.c
@@ -381,7 +381,7 @@ Ensure(Mocks, constraint_number_of_calls_order_of_expectations_matter) {
 }
 
 static int sideeffect_changed = 1;
-static int mock_with_sideeffect(void) {
+static int mock_with_side_effect(void) {
     return (int)mock();
 }
 static void the_sideeffect(void * data) {
@@ -389,13 +389,13 @@ static void the_sideeffect(void * data) {
     sideeffect_changed = 2;
 }
 
-Ensure(Mocks, mock_expect_with_sideeffect) {
+Ensure(Mocks, mock_expect_with_side_effect) {
 	int data_passed_to_sideeffect = 99;
-    expect(mock_with_sideeffect,
-           with_sideeffect(&the_sideeffect, &data_passed_to_sideeffect),
+    expect(mock_with_side_effect,
+           with_side_effect(&the_sideeffect, &data_passed_to_sideeffect),
            will_return(22));
 
-    assert_that(mock_with_sideeffect(), is_equal_to(22));
+    assert_that(mock_with_side_effect(), is_equal_to(22));
 
     assert_that(sideeffect_changed, is_equal_to(2));
 }
@@ -433,7 +433,7 @@ TestSuite *mock_tests(void) {
     add_test_with_context(suite, Mocks, constraint_number_of_calls_when_is_present);
     add_test_with_context(suite, Mocks, constraint_number_of_calls_when_multiple_expectations_are_present);
     add_test_with_context(suite, Mocks, constraint_number_of_calls_order_of_expectations_matter);
-    add_test_with_context(suite, Mocks, mock_expect_with_sideeffect);
+    add_test_with_context(suite, Mocks, mock_expect_with_side_effect);
 
     return suite;
 }


### PR DESCRIPTION
In this PR you can find the implementation of the side effect that was discussed in #103.
The syntax to use the side effect constraint is:
```
expect(some_mock, with_sideeffect(&some_side_effect_callback,
                                  (void*)&some_side_effect_data);
```
In order to do this we leveraged the `CALL` Type.

Fixes #103 