### PR TITLE
Add return by value

### DIFF
--- a/contrib/cgreen-mocker/.gitignore
+++ b/contrib/cgreen-mocker/.gitignore
@@ -1,2 +1,3 @@
 double.mock
+complex_types.mock
 pycparser

--- a/contrib/cgreen-mocker/Makefile
+++ b/contrib/cgreen-mocker/Makefile
@@ -13,3 +13,17 @@ all:
 	@echo "------------------------------------------"
 	@cat double.mock
 	@echo "------------------------------------------"
+	@echo "With the command:"
+	@echo "-----------------"
+	./cgreen-mocker.py complex_types.h > complex_types.mock
+	@echo "-----------------"
+	@echo "'cgreen-mocker' reads a C header file and transforms any"
+	@echo "function declarations into corresponding Cgreen mocks."
+	@echo "Here's the input:"
+	@echo "-----------------"
+	@cat complex_types.h
+	@echo "-----------------"
+	@echo "And here's the resulting mock declaration:"
+	@echo "------------------------------------------"
+	@cat complex_types.mock
+	@echo "------------------------------------------"

--- a/contrib/cgreen-mocker/complex_types.h
+++ b/contrib/cgreen-mocker/complex_types.h
@@ -1,0 +1,9 @@
+typedef struct BasicStruct {
+    int someValue;
+} BasicStruct;
+
+typedef BasicStruct* BasicStructPtr;
+
+BasicStruct return_by_value(void);
+BasicStructPtr return_pointer_to_struct(void);
+BasicStruct* direct_return_pointer_to_struct(void);

--- a/doc/cgreen-guide-en.asciidoc
+++ b/doc/cgreen-guide-en.asciidoc
@@ -1734,7 +1734,8 @@ Then there are two ways to return results:
 
 |===========================================================================================
 |*Macro*                                                      |*Description*
-|`will_return(value)`                                         |Return the value from the mock function (which needs to be declared returning that type
+|`will_return(value)`                                         |Return the value from the mock function (which needs to be declared returning that type)
+|`will_return_by_value(value, size)`                          |Ditto for generic by value variables.
 |`will_return_double(value)`                                  |Ditto for double values (required because of C's type coercion rules which would otherwise convert a double into an int)
 |`will_set_contents_of_parameter(parameter_name, value, size)`|Writes the value in the referenced parameter
 |`with_side_effect(pointer_to_function, pointer_to_data)`     |Executes the side effect function and passes data to it
@@ -1800,6 +1801,23 @@ The expectation code should look like the following
   expect(mocked_file_writer,
         when(data, is_equal_to(42)),
         times(1));
+-----------------------
+
+To use a return by value function `will_return_by_value` we can use the following code:
+
+[source,c]
+-----------------------
+  expect(retrieve_box,
+        will_return_by_value(box, sizeof(Box));
+-----------------------
+
+And the mocked function need to look like:
+
+[source,c]
+-----------------------
+Box retrieve_box() {
+   return *(Box *)mock();
+}
 -----------------------
 
 It's about time we actually ran our test...

--- a/include/cgreen/cgreen_value.h
+++ b/include/cgreen/cgreen_value.h
@@ -2,8 +2,9 @@
 #define CGREEN_VALUE_HEADER
 
 #include <stdint.h>
+#include <stddef.h>
 
-typedef enum {INTEGER, STRING, DOUBLE, POINTER} CgreenValueType;
+typedef enum {INTEGER, STRING, DOUBLE, POINTER, BYVALUE} CgreenValueType;
 
 typedef struct {
     CgreenValueType type;
@@ -13,6 +14,7 @@ typedef struct {
         void *pointer_value;
         const char *string_value;
     } value;
+    size_t value_size;
 } CgreenValue;
 
 #endif

--- a/include/cgreen/constraint.h
+++ b/include/cgreen/constraint.h
@@ -16,6 +16,7 @@ typedef enum {
     DOUBLE_COMPARER,
     RETURN_VALUE,
     CONTENT_SETTER,
+    RETURN_POINTER,
     CALL,
     CALL_COUNTER
 } ConstraintType;
@@ -77,6 +78,7 @@ Constraint *create_not_equal_to_double_constraint(double expected_value, const c
 Constraint *create_less_than_double_constraint(double expected_value, const char *expected_value_name);
 Constraint *create_greater_than_double_constraint(double expected_value, const char *expected_value_name);
 Constraint *create_return_value_constraint(intptr_t value_to_return);
+Constraint *create_return_by_value_constraint(intptr_t value_to_return, size_t size);
 Constraint *create_return_double_value_constraint(double value_to_return);
 Constraint *create_set_parameter_value_constraint(const char *parameter_name, intptr_t value_to_set, size_t size_to_set);
 Constraint *create_with_side_effect_constraint(void (*callback)(void *), void *data);

--- a/include/cgreen/constraint_syntax_helpers.h
+++ b/include/cgreen/constraint_syntax_helpers.h
@@ -43,6 +43,7 @@
 
 #define with_side_effect(callback, data) create_with_side_effect_constraint(callback, data)
 #define will_return(value) create_return_value_constraint((intptr_t)value)
+#define will_return_by_value(value, size) create_return_by_value_constraint((intptr_t)&value, size)
 #define will_return_double(value) create_return_double_value_constraint(value)
 #define will_set_contents_of_parameter(parameter_name, value, size) create_set_parameter_value_constraint(#parameter_name, (intptr_t)value, (size_t)size)
 

--- a/src/cgreen_value.c
+++ b/src/cgreen_value.c
@@ -2,6 +2,7 @@
 #include <stdint.h>
 #include <stdlib.h>
 #include <string.h>
+#include <include/cgreen/cgreen_value.h>
 
 static char *stringdup(const char *string) {
     if (string == NULL)
@@ -17,30 +18,38 @@ CgreenValue *create_cgreen_value(CgreenValue value) {
 }
 
 CgreenValue make_cgreen_integer_value(intptr_t integer) {
-    CgreenValue value = {INTEGER, {0}};
+    CgreenValue value = {INTEGER, {0}, sizeof(intptr_t)};
     value.value.integer_value = integer;
     return value;
 }
 
 CgreenValue make_cgreen_string_value(const char *string) {
-    CgreenValue value = {STRING, {0}};
+    CgreenValue value = {STRING, {0}, sizeof(const char *)};
     value.value.string_value = stringdup(string);
     return value;
 }
 
 CgreenValue make_cgreen_pointer_value(void *pointer) {
-    CgreenValue value = {POINTER, {0}};
+    CgreenValue value = {POINTER, {0}, sizeof(intptr_t)};
     value.value.pointer_value = pointer;
     return value;
 }
 
 CgreenValue make_cgreen_double_value(double d) {
-    CgreenValue value = {DOUBLE, {0}};
+    CgreenValue value = {DOUBLE, {0}, sizeof(intptr_t)};
     value.value.double_value = d;
+    return value;
+}
+
+CgreenValue make_cgreen_by_value(void *pointer, size_t size) {
+    CgreenValue value = {BYVALUE, {0}, size};
+    value.value.pointer_value = pointer;
     return value;
 }
 
 void destroy_cgreen_value(CgreenValue value) {
     if (value.type == STRING)
         free((void *)value.value.string_value);
+    else if (value.type == BYVALUE)
+        free(value.value.pointer_value);
 }

--- a/src/cgreen_value_internal.h
+++ b/src/cgreen_value_internal.h
@@ -14,6 +14,7 @@ extern CgreenValue make_cgreen_integer_value(intptr_t integer);
 extern CgreenValue make_cgreen_string_value(const char *string);
 extern CgreenValue make_cgreen_double_value(double value);
 extern CgreenValue make_cgreen_pointer_value(void *ptr);
+extern CgreenValue make_cgreen_by_value(void *pointer, size_t size);
 extern void destroy_cgreen_value(CgreenValue value);
 
 #ifdef __cplusplus

--- a/src/constraint.c
+++ b/src/constraint.c
@@ -405,6 +405,20 @@ Constraint *create_return_value_constraint(intptr_t value_to_return) {
     return constraint;
 }
 
+Constraint *create_return_by_value_constraint(intptr_t value_to_return, size_t size) {
+    intptr_t actual_return = (intptr_t) malloc(size);
+    memcpy((void*)actual_return, (void*)value_to_return, size);
+    Constraint* constraint = create_constraint();
+    constraint->type = RETURN_VALUE;
+
+    constraint->compare = &compare_true;
+    constraint->execute = &test_true;
+    constraint->name = "return value";
+    constraint->expected_value = make_cgreen_by_value((void*)actual_return, size);
+
+    return constraint;
+}
+
 Constraint *create_return_double_value_constraint(double value_to_return) {
     Constraint* constraint = create_constraint();
     constraint->type = RETURN_VALUE;

--- a/src/mocks.c
+++ b/src/mocks.c
@@ -891,6 +891,8 @@ static CgreenValue stored_result_or_default_for(CgreenVector* constraints) {
 
         if (constraint->type == RETURN_VALUE) {
             return constraint->expected_value;
+        } else if (constraint->type == RETURN_POINTER) {
+            return constraint->expected_value;
         }
     }
 

--- a/tests/all_c_tests.c
+++ b/tests/all_c_tests.c
@@ -35,6 +35,7 @@ int main(int argc, char **argv) {
 
     add_suite(suite, assertion_tests());
     add_suite(suite, breadcrumb_tests());
+    add_suite(suite, cgreen_value_tests());
     add_suite(suite, cdash_reporter_tests());
     add_suite(suite, constraint_tests());
 #ifdef __cplusplus

--- a/tests/cgreen_value_tests.c
+++ b/tests/cgreen_value_tests.c
@@ -1,4 +1,5 @@
 #include <cgreen/cgreen.h>
+#include <include/cgreen/cgreen_value.h>
 
 #include "cgreen_value_internal.h"
 
@@ -37,4 +38,23 @@ Ensure(CgreenValue, makes_double_value) {
     assert_that(value.type, is_equal_to(DOUBLE));
     assert_that_double(value.value.double_value, is_equal_to_double(3.1415926));
     destroy_cgreen_value(value);
+}
+
+Ensure(CgreenValue, makes_by_value) {
+    char * actualString = "1234";
+    CgreenValue value = make_cgreen_by_value(actualString, 4);
+    assert_that(value.type, is_equal_to(BYVALUE));
+    assert_that(value.value.pointer_value, is_equal_to_string("1234"));
+}
+
+TestSuite *cgreen_value_tests(void) {
+    TestSuite *suite = create_test_suite();
+
+    add_test_with_context(suite, CgreenValue, makes_integer_value);
+    add_test_with_context(suite, CgreenValue, makes_string_value);
+    add_test_with_context(suite, CgreenValue, makes_pointer_value);
+    add_test_with_context(suite, CgreenValue, makes_double_value);
+    add_test_with_context(suite, CgreenValue, makes_by_value);
+
+    return suite;
 }

--- a/tests/mocks_tests.c
+++ b/tests/mocks_tests.c
@@ -401,6 +401,45 @@ Ensure(Mocks, mock_expect_with_side_effect) {
 }
 
 
+typedef struct Box {
+    int height;
+    int weight;
+} Box;
+
+Box retrieveBox(void) {
+    return *(Box *)mock();
+}
+
+Ensure(Mocks, can_return_by_value) {
+    Box someBox = {.height = 10, .weight = 20};
+    expect(retrieveBox, will_return_by_value(someBox, sizeof(Box)));
+    someBox.height = 30;
+
+    Box actualBox = retrieveBox();
+    assert_that(actualBox.weight, is_equal_to(20));
+    assert_that(actualBox.height, is_equal_to(10));
+}
+
+Box retrieveSpecialBox(int boxNumber) {
+    return *(Box *)mock(boxNumber);
+}
+
+Ensure(Mocks, can_return_by_value_depending_on_input_parameter) {
+    Box box1 = {.height = 10, .weight = 20};
+    Box box2 = {.height = 5, .weight = 33};
+    expect(retrieveSpecialBox, will_return_by_value(box1, sizeof(Box)), when(boxNumber, is_equal_to(1)));
+    expect(retrieveSpecialBox, will_return_by_value(box2, sizeof(Box)), when(boxNumber, is_equal_to(2)));
+    box1.height = 30;
+
+    Box retrievedBox1 = retrieveSpecialBox(1);
+    assert_that(retrievedBox1.weight, is_equal_to(20));
+    assert_that(retrievedBox1.height, is_equal_to(10));
+    Box retrievedBox2 = retrieveSpecialBox(2);
+    assert_that(retrievedBox2.weight, is_equal_to(33));
+    assert_that(retrievedBox2.height, is_equal_to(5));
+}
+
+
 TestSuite *mock_tests(void) {
     TestSuite *suite = create_test_suite();
     add_test_with_context(suite, Mocks, default_return_value_when_no_presets_for_loose_mock);
@@ -434,6 +473,8 @@ TestSuite *mock_tests(void) {
     add_test_with_context(suite, Mocks, constraint_number_of_calls_when_multiple_expectations_are_present);
     add_test_with_context(suite, Mocks, constraint_number_of_calls_order_of_expectations_matter);
     add_test_with_context(suite, Mocks, mock_expect_with_side_effect);
+    add_test_with_context(suite, Mocks, can_return_by_value);
+    add_test_with_context(suite, Mocks, can_return_by_value_depending_on_input_parameter);
 
     return suite;
 }


### PR DESCRIPTION
This PR adds the support for a new function called `will_return_by_value`
The new method will receive a variable that represent a return type by value and the size of the structure.

The idea is that internally Cgreen will allocate dynamic memory to store the value that was passed into the `will_return_by_value`, copies the amount of memory needed. Afterward the mock will need to dereference the return value of the mock. Example:

```
Box retrieve_box() {
   return *(Box *)mock();
}
```

Where `Box` is a basic structure

Also the PR improves the cgreen-mocker by adding the ability to return by value when the return type is a structure.
Fixes #163