### PR TITLE
Add `times` constraint

### DIFF
--- a/doc/cgreen-guide-en.asciidoc
+++ b/doc/cgreen-guide-en.asciidoc
@@ -1736,6 +1736,44 @@ You can also have multiple `will_set_contents_of_parameter()` in an
 expectation, one for each reference parameter, but naturally only one
 `will_return()`.
 
+To ensure that a specific call happens `n` times the macro `times(number_times_called)` can be passed
+as a constraint to a specific call:
+
+[source,c]
+-----------------------
+  expect(mocked_file_writer,
+        when(data, is_equal_to(42)),
+        times(1));
+-----------------------
+
+This feature only works for `expect`.
+
+The expections still need to respect the order of calling, so if we call the function
+`mocker_file_writer` with the following pattern:
+
+[source,c]
+-----------------------
+  mocked_file_writer(42);
+  mocked_file_writer(42);
+  mocked_file_writer(43);
+  mocked_file_writer(42);
+-----------------------
+
+The expectation code should look like the following
+
+[source,c]
+-----------------------
+  expect(mocked_file_writer,
+        when(data, is_equal_to(42)),
+        times(2));
+  expect(mocked_file_writer,
+        when(data, is_equal_to(43)),
+        times(1));
+  expect(mocked_file_writer,
+        when(data, is_equal_to(42)),
+        times(1));
+-----------------------
+
 It's about time we actually ran our test...
 
 -----------------------

--- a/include/cgreen/constraint.h
+++ b/include/cgreen/constraint.h
@@ -16,7 +16,8 @@ typedef enum {
     DOUBLE_COMPARER,
     RETURN_VALUE,
     CONTENT_SETTER,
-    CALL
+    CALL,
+    CALL_COUNTER
 } ConstraintType;
 
 typedef struct Constraint_ Constraint;

--- a/include/cgreen/internal/mocks_internal.h
+++ b/include/cgreen/internal/mocks_internal.h
@@ -42,6 +42,8 @@ extern intptr_t mock_(TestReporter *test_reporter, const char *function, const c
 */
 extern Constraint *when_(const char *parameter, Constraint *constraint) WARN_UNUSED_RESULT;
 
+extern Constraint *times_(int number_times_called);
+
 extern void clear_mocks(void);
 extern void tally_mocks(TestReporter *reporter);
 

--- a/include/cgreen/mocks.h
+++ b/include/cgreen/mocks.h
@@ -36,6 +36,8 @@ namespace cgreen {
 
 #define when(parameter, constraint) when_(#parameter, constraint)
 
+#define times(number_times_called) times_(number_times_called)
+
 /* Make Cgreen mocks strict, loose or learning */
 typedef enum { strict_mocks = 0, loose_mocks = 1, learning_mocks = 2 } CgreenMockMode;
 extern void cgreen_mocks_are(CgreenMockMode mode);

--- a/tests/mock_messages_tests.c
+++ b/tests/mock_messages_tests.c
@@ -152,3 +152,19 @@ xEnsure(Mocks, learning_mocks_survive_termination) {
     string_out(1);
     *ip = 0;
 }
+
+static void simple_mocked_function(int first, int second) {
+    mock(first, second);
+}
+
+Ensure(Mocks, constraint_number_of_calls_when_not_called_enough_times) {
+    expect(simple_mocked_function, times(2));
+    simple_mocked_function(1, 2);
+}
+
+Ensure(Mocks, constraint_number_of_calls_out_of_order_expectations_fail) {
+    expect(simple_mocked_function, when(first, is_equal_to(1)), times(1));
+    expect(simple_mocked_function, when(first, is_equal_to(2)), times(1));
+    simple_mocked_function(2, 2);
+    simple_mocked_function(1, 2);
+}

--- a/tests/mock_messages_tests.expected
+++ b/tests/mock_messages_tests.expected
@@ -1,4 +1,4 @@
-Running "mock_messages_tests" (13 tests)...
+Running "mock_messages_tests" (15 tests)...
 mock_messages_tests.c: Failure: Mocks -> calls_beyond_expected_sequence_fail_when_mocks_are_strict 
 	Mocked function [integer_out] was called too many times
 
@@ -9,6 +9,21 @@ mock_messages_tests.c: Failure: Mocks -> calls_beyond_expected_sequence_fail_whe
 
 mock_messages_tests.c: Failure: Mocks -> can_declare_function_never_called 
 	Mocked function [sample_mock] has an expectation that it will never be called, but it was
+
+mock_messages_tests.c: Failure: Mocks -> constraint_number_of_calls_out_of_order_expectations_fail 
+	Expected [[first] parameter in [simple_mocked_function]] to [equal] [1]
+		actual value:			[2]
+		expected value:			[1]
+
+mock_messages_tests.c: Failure: Mocks -> constraint_number_of_calls_out_of_order_expectations_fail 
+	Expected [[first] parameter in [simple_mocked_function]] to [equal] [2]
+		actual value:			[1]
+		expected value:			[2]
+
+mock_messages_tests.c: Failure: Mocks -> constraint_number_of_calls_when_not_called_enough_times 
+	Expected [simple_mocked_function] to [be called] [times]
+		actual value:			[1]
+		expected to have been called:	[2] times
 
 mock_messages_tests.c: Failure: Mocks -> failure_reported_when_expect_after_always_expect_for_same_function 
 	Mocked function [integer_out] already has an expectation that it will always be called a certain way; any expectations declared after an always expectation are invalid
@@ -28,8 +43,8 @@ mock_messages_tests.c: Failure: Mocks -> reports_multiple_never_expect
 mock_messages_tests.c: Failure: Mocks -> single_uncalled_expectation_fails_tally 
 	Expected call was not made to mocked function [string_out]
 
-  "Mocks": 4 passes, 2 skipped, 9 failures in 0ms.
-Completed "mock_messages_tests": 4 passes, 2 skipped, 9 failures in 0ms.
+  "Mocks": 4 passes, 2 skipped, 12 failures in 0ms.
+Completed "mock_messages_tests": 4 passes, 2 skipped, 12 failures in 0ms.
 Mocks -> can_learn_double_expects : Learned mocks are
 	expect(double_in, when(in, is_equal_to_double(3.140000)));
 Mocks -> learning_mocks_emit_none_when_learning_no_mocks : Learned mocks are

--- a/tests/mocks_tests.c
+++ b/tests/mocks_tests.c
@@ -347,6 +347,39 @@ Ensure(Mocks, can_mock_a_function_macro) {
 
 #undef FUNCTION_MACRO
 
+static void simple_mocked_function(int first, int second) {
+    mock(first, second);
+}
+
+Ensure(Mocks, constraint_number_of_calls_when_no_when_is_present) {
+    expect(simple_mocked_function, times(2));
+    simple_mocked_function(1, 2);
+    simple_mocked_function(1, 2);
+}
+
+Ensure(Mocks, constraint_number_of_calls_when_is_present) {
+    expect(simple_mocked_function, when(first, is_equal_to(1)), times(2));
+    simple_mocked_function(1, 2);
+    simple_mocked_function(1, 2);
+}
+
+Ensure(Mocks, constraint_number_of_calls_when_multiple_expectations_are_present) {
+    expect(simple_mocked_function, when(first, is_equal_to(1)), times(2));
+    expect(simple_mocked_function, when(first, is_equal_to(2)), times(1));
+    simple_mocked_function(1, 2);
+    simple_mocked_function(1, 2);
+    simple_mocked_function(2, 2);
+}
+
+Ensure(Mocks, constraint_number_of_calls_order_of_expectations_matter) {
+    expect(simple_mocked_function, when(first, is_equal_to(1)), times(1));
+    expect(simple_mocked_function, when(first, is_equal_to(2)), times(1));
+    expect(simple_mocked_function, when(first, is_equal_to(1)), times(1));
+    simple_mocked_function(1, 2);
+    simple_mocked_function(2, 2);
+    simple_mocked_function(1, 2);
+}
+
 
 TestSuite *mock_tests(void) {
     TestSuite *suite = create_test_suite();
@@ -376,6 +409,10 @@ TestSuite *mock_tests(void) {
     add_test_with_context(suite, Mocks, can_stub_an_out_parameter);
     add_test_with_context(suite, Mocks, string_contains_expectation_is_confirmed);
     add_test_with_context(suite, Mocks, can_mock_a_function_macro);
+    add_test_with_context(suite, Mocks, constraint_number_of_calls_when_no_when_is_present);
+    add_test_with_context(suite, Mocks, constraint_number_of_calls_when_is_present);
+    add_test_with_context(suite, Mocks, constraint_number_of_calls_when_multiple_expectations_are_present);
+    add_test_with_context(suite, Mocks, constraint_number_of_calls_order_of_expectations_matter);
 
     return suite;
 }


### PR DESCRIPTION
In this commit the constraint that expect a mock to be invoked a specific number of times is added.

The implementation piggyback on the `time_to_live` of a recorder expectation to ensure it gets cleaned correctly when it is no longer expected.

To ensure a better error message a variable to store the number of times a specific mock was called was added to the structure `RecordedExpectation`.

The syntax that I selected for this was 
```
expect(function_name, times(3));
```

It looks more clean and also reads better, at least in my opinion.

Fixes issue #70 