### PR TITLE
Fix overflows

### DIFF
--- a/src/cdash_reporter_internal.h
+++ b/src/cdash_reporter_internal.h
@@ -1,12 +1,16 @@
 #ifndef CDASH_REPORTER_INTERNAL_H
 #define CDASH_REPORTER_INTERNAL_H
 
+#include <stdarg.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif
 
 typedef int CDashPrinter(FILE *, const char *format, ...);
+typedef int CDashVPrinter(FILE *, const char *format, va_list arguments);
 void set_cdash_reporter_printer(TestReporter *reporter, CDashPrinter *printer);
+void set_cdash_reporter_vprinter(TestReporter *reporter, CDashVPrinter *vprinter);
 
 #ifdef __cplusplus
 }

--- a/src/cute_reporter_internal.h
+++ b/src/cute_reporter_internal.h
@@ -1,12 +1,17 @@
 #ifndef CUTE_REPORTER_INTERNAL_H
 #define CUTE_REPORTER_INTERNAL_H
 
+#include <stdarg.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif
 
 typedef int CutePrinter(const char *format, ...);
+typedef int CuteVPrinter(const char *format, va_list arguments);
+
 extern void set_cute_reporter_printer(TestReporter *reporter, CutePrinter *printer);
+extern void set_cute_reporter_vprinter(TestReporter *reporter, CuteVPrinter *vprinter);
 
 #ifdef __cplusplus
 }

--- a/src/text_reporter_internal.h
+++ b/src/text_reporter_internal.h
@@ -1,12 +1,17 @@
 #ifndef TEXT_REPORTER_INTERNAL_H
 #define TEXT_REPORTER_INTERNAL_H
 
+#include <stdarg.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif
 
 typedef int TextPrinter(const char *format, ...);
+typedef int TextVPrinter(const char *format, va_list arguments);
+
 extern void set_text_reporter_printer(TestReporter *reporter, TextPrinter *printer);
+extern void set_text_reporter_vprinter(TestReporter *reporter, TextVPrinter *vprinter);
 
 #ifdef __cplusplus
 }

--- a/tests/cdash_reporter_tests.c
+++ b/tests/cdash_reporter_tests.c
@@ -31,17 +31,25 @@ static char *concat(char *output, char *buffer) {
     return output;
 }
 
-static int mocked_printer(FILE *stream, const char *format, ...) {
-    char buffer[10000];
-    va_list ap;
-    va_start(ap, format);
-    vsprintf(buffer, format, ap);
-    va_end(ap);
-
+static int mocked_vprinter(FILE *stream, const char *format, va_list ap) {
     (void)stream;               /* Unused */
+
+    char buffer[10000];
+    vsprintf(buffer, format, ap);
     
     output = concat(output, buffer);
     return strlen(output);
+}
+
+static int mocked_printer(FILE *stream, const char *format, ...) {
+    int result = 0;
+
+    va_list ap;
+    va_start(ap, format);
+    result = mocked_vprinter(stream, format, ap);
+    va_end(ap);
+
+    return result;
 }
 
 static TestReporter *reporter;
@@ -58,6 +66,7 @@ static void setup_cdash_reporter_tests(void) {
 
     clear_output();
     set_cdash_reporter_printer(reporter, mocked_printer);
+    set_cdash_reporter_vprinter(reporter, mocked_vprinter);
 }
 
 static void teardown_cdash_reporter_tests(void) {
@@ -126,6 +135,30 @@ Ensure(CDashReporter, will_report_failed_once_for_each_fail) {
 
     clear_output();
     
+    // Must indicate test case completion before calling finish_test()
+    send_reporter_completion_notification(reporter);
+    reporter->finish_test(reporter, "filename", line, NULL);
+    assert_that(output, is_equal_to_string(""));
+}
+
+static void wrapped_show_fail(TestReporter *reporter, const char *file, int line,
+        const char *message, ...) {
+   va_list arguments;
+   va_start(arguments, message);
+   reporter->show_fail(reporter, file, line, message, arguments);
+   va_end(arguments);
+}
+
+Ensure(CDashReporter, will_use_arguments_for_show_fail) {
+    reporter->start_test(reporter, "test_name");
+
+    reporter->failures++;   // Simulating a failed assert
+    wrapped_show_fail(reporter, "file", 2, "test_case %i is %s", 5, "alive");
+
+    assert_that(output, contains_string("<Value>test_case 5 is alive</Value>"));
+
+    clear_output();
+
     // Must indicate test case completion before calling finish_test()
     send_reporter_completion_notification(reporter);
     reporter->finish_test(reporter, "filename", line, NULL);

--- a/tests/cute_reporter_tests.c
+++ b/tests/cute_reporter_tests.c
@@ -33,15 +33,24 @@ static char *concat(char *output, char *buffer) {
     return output;
 }
 
-static int mocked_printf(const char *format, ...) {
+static int mocked_vprintf(const char *format, va_list arguments) {
     char buffer[10000];
-    va_list ap;
-    va_start(ap, format);
-    vsprintf(buffer, format, ap);
-    va_end(ap);
+
+    vsprintf(buffer, format, arguments);
 
     output = concat(output, buffer);
     return strlen(output);
+}
+
+static int mocked_printf(const char *format, ...) {
+   int result = 0;
+
+   va_list ap;
+   va_start(ap, format);
+   result = mocked_vprintf(format, ap);
+   va_end(ap);
+
+   return result;
 }
 
 static TestReporter *reporter;
@@ -56,6 +65,7 @@ static void setup_cute_reporter_tests(void) {
 
     clear_output();
     set_cute_reporter_printer(reporter, mocked_printf);
+    set_cute_reporter_vprinter(reporter, mocked_vprintf);
 }
 
 static void teardown_cute_reporter_tests(void) {
@@ -124,6 +134,31 @@ Ensure(CuteReporter, will_report_failing_of_test_only_once) {
     reporter->failures++;   // Simulating another failed assert
     reporter->show_fail(reporter, "file", 2, "test_name", arguments);
     assert_no_output();
+
+    // Must indicate test case completion before calling finish_test()
+    send_reporter_completion_notification(reporter);
+    reporter->finish_test(reporter, "filename", line, NULL);
+    assert_no_output();
+}
+
+static void wrapped_show_fail(TestReporter *reporter, const char *file, int line,
+        const char *message, ...) {
+   va_list arguments;
+   va_start(arguments, message);
+   reporter->show_fail(reporter, file, line, message, arguments);
+   va_end(arguments);
+}
+
+Ensure(CuteReporter, will_use_arguments_for_show_fail) {
+    reporter->start_test(reporter, "test_name");
+
+    clear_output();
+    reporter->failures++;   // Simulating a failed assert
+    wrapped_show_fail(reporter, "file", 2, "test_case %i provides %s", 42, "the answer");
+    assert_that(output, begins_with_string("#failure"));
+    assert_that(output, contains_string("test_case 42 provides the answer"));
+
+    clear_output();
 
     // Must indicate test case completion before calling finish_test()
     send_reporter_completion_notification(reporter);


### PR DESCRIPTION
I've written a test with an older version that compared two very long strings. As also described in #167 I encountered a buffer overflow and the test crashed hard.

So this PR does something similar as #167 -> Fix potential overflows.

The difference to #167 is, that I completely removed the intermediate buffering and did the same for cdash_reporter and cute_reporter