### PR TITLE
Fixed warnings in user's tests with '-pedantic'

### DIFF
--- a/include/cgreen/internal/assertions_internal.h
+++ b/include/cgreen/internal/assertions_internal.h
@@ -16,7 +16,7 @@ namespace cgreen {
 #endif
 
 //At the cost of duplication, these macros now give more descriptive error messages
-#define ASSERT_THAT_VA_NUM_ARGS(...) ASSERT_THAT_VA_NUM_ARGS_IMPL_((__VA_ARGS__, _CALLED_WITH_TOO_MANY_ARGS,  _constraint,  _expression))
+#define ASSERT_THAT_VA_NUM_ARGS(...) ASSERT_THAT_VA_NUM_ARGS_IMPL_((__VA_ARGS__, _CALLED_WITH_TOO_MANY_ARGS,  _constraint,  _expression, DummyToFillVaArgs))
 #define ASSERT_THAT_VA_NUM_ARGS_IMPL_(tuple) ASSERT_THAT_VA_NUM_ARGS_IMPL tuple
 
 #define ASSERT_THAT_VA_NUM_ARGS_IMPL(_1, _2, _3, N, ...) N

--- a/include/cgreen/internal/unit_implementation.h
+++ b/include/cgreen/internal/unit_implementation.h
@@ -29,7 +29,7 @@ typedef struct {
 #define spec_name(contextName, testName) CgreenSpec__##contextName##__##testName##__
 
 //This gives better error messages at the cost of duplication
-#define ENSURE_VA_NUM_ARGS(...) ENSURE_VA_NUM_ARGS_IMPL_((__VA_ARGS__, _CALLED_WITH_TOO_MANY_ARGUMENTS,  WithContextAndSpecificationName,  WithSpecificationName))
+#define ENSURE_VA_NUM_ARGS(...) ENSURE_VA_NUM_ARGS_IMPL_((__VA_ARGS__, _CALLED_WITH_TOO_MANY_ARGUMENTS,  WithContextAndSpecificationName,  WithSpecificationName, DummyToFillVaArgs))
 #define ENSURE_VA_NUM_ARGS_IMPL_(tuple) ENSURE_VA_NUM_ARGS_IMPL tuple
 
 #define ENSURE_VA_NUM_ARGS_IMPL(_1, _2, _3, _4, N, ...) N
@@ -43,14 +43,14 @@ typedef struct {
 
 #define Ensure_NARG(...) ENSURE_macro_dispatcher(Ensure, __VA_ARGS__)
 
-#define EnsureWithContextAndSpecificationName(skip, contextName, specName, ...) \
+#define EnsureWithContextAndSpecificationName(skip, contextName, specName) \
     static void contextName##__##specName (void);\
     CgreenTest spec_name(contextName, specName) = { skip, &contextFor##contextName, STRINGIFY_TOKEN(specName), &contextName##__##specName, __FILE__, __LINE__ }; \
     static void contextName##__##specName (void)
 
 extern CgreenContext defaultContext;
 
-#define EnsureWithSpecificationName(skip, specName, ...)   \
+#define EnsureWithSpecificationName(skip, specName) \
     static void specName (void);\
     CgreenTest spec_name(default, specName) = { skip, &defaultContext, STRINGIFY_TOKEN(specName), &specName, __FILE__, __LINE__ }; \
     static void specName (void)
@@ -66,7 +66,8 @@ extern CgreenContext defaultContext;
         }                                                               \
         static void teardown(void) {                                    \
             if (AfterEach_For_##subject != NULL) AfterEach_For_##subject(); \
-        }
+        }                                                               \
+        typedef struct Dummy_ ## subject { int x; } Dummy_ ## subject ## _t
 
 #define BeforeEachImplementation(subject) \
         void BeforeEach_For_##subject##_Function(void);                 \


### PR DESCRIPTION
When I compile my own system's unit tests I use the -pedantic switch
of gcc. There are then some warnings reported which are caused by
cgreen's headers.

This commit fixes some variadic macros and adds a "dummy line" to
'Describe()' so the compiler takes the trailing semicolon.