### PR TITLE
make without cmake installed will fail, even if cmake is installed afterwards.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@
 # That should build Cgreen in the build directory, run some tests,
 # install it locally and generate a distributable package.
 
-all: build
+all: build/Makefile
 	cd build; make
 
 .PHONY:debug
@@ -24,15 +24,15 @@ debug: build
 	-rm -rf build; mkdir build; cd build; cmake -DCMAKE_C_FLAGS="-m32" -DCMAKE_CXX_FLAGS="-m32" ..; make
 
 .PHONY:test
-test: build
+test: build/Makefile
 	cd build; make check
 
 .PHONY:clean
-clean: build
+clean: build/Makefile
 	cd build; make clean
 
 .PHONY:package
-package: build
+package: build/Makefile
 	cd build; make package
 
 .PHONY:install
@@ -123,11 +123,13 @@ valgrind: build-it
 
 ############# Internal
 
-build-it: build
+build-it: build/Makefile
 	make -C build
 
 build:
 	mkdir build
+
+build/Makefile: build
 	cd build; cmake $(ARCHS) ..
 
 .SILENT:


### PR DESCRIPTION
I have been bitten twice by this during installation of cgreen on a fresh system.

$ make
GNU/Linux
bash: cmake: command not found
make: *** [build] Error 127

Oh, no cmake. Ok, lets install it.
$ apt-get install cmake

Lets try again!
$ make 
GNU/Linux
make[1]: *** No targets specified and no makefile found.  Stop.
make: *** [all] Error 2

What?

Cause
Makefile combines creation of build dir with generation of build/Makefile. The generation of build/Makefile fails if cmake is not installed. Other target only have the build dir as dependency and incorrectly assume that the build/Makefile will be there.

Fix
Made the other targets depended directly on the build/Makefile. This will cause it to be generated when it's missing.

The issue can be reproduced with on systems that have cmake installed, and don't want to remove it, with the following commands.
rm -rf build ; # remove build dir, this doesn't exist after a clone.
mkdir /tmp/fake_cmake ; # the following three step simulate a uninstalled cmake.
chmod +x /tmp/fake_cmake/cmake
echo 'echo >&2 "bash: cmake: command not found" && exit 127' > /tmp/fake_cmake/cmake
PATH="/tmp/fake_cmake:$PATH" make ; # Run make as if cmake is not installed
make ; # Run make, with cmake installed.