### PR TITLE
Fix Issue #193 xml reporter broken if test failed with segfault

### DIFF
--- a/src/xml_reporter.c
+++ b/src/xml_reporter.c
@@ -210,19 +210,20 @@ static void xml_show_fail(TestReporter *reporter, const char *file, int line, co
 }
 
 static void xml_show_incomplete(TestReporter *reporter, const char *filename, int line, const char *message, va_list arguments) {
-    XmlMemo *memo = (XmlMemo *)reporter->memo;
-    FILE *out = file_stack[file_stack_p-1];
+    char buffer[1000];
 
-    memo->printer(out, ">\n");
-    memo->printer(out, indent(reporter));
-    memo->printer(out, "<error type=\"Fatal\" message=\"");
-    memo->printer(out, message ? message: "Test terminated unexpectedly, likely from a non-standard exception or Posix signal", arguments);
-    memo->printer(out, "\">\n");
-    memo->printer(out, indent(reporter));
-    memo->printer(out, "\t<location file=\"%s\" line=\"%d\"/>\n", filename, line);
-    memo->printer(out, indent(reporter));
-    memo->printer(out, "</error>\n");
-    fflush(out);
+    output = concat(output, indent(reporter));
+    output = concat(output, "<error type=\"Fatal\" message=\"");
+    vsnprintf(buffer, sizeof(buffer)/sizeof(buffer[0]),
+    		message ? message: "Test terminated unexpectedly, likely from a non-standard exception or Posix signal", arguments);
+    output = concat(output, buffer);
+    output = concat(output, "\">\n");
+    output = concat(output, indent(reporter));
+    snprintf(buffer, sizeof(buffer)/sizeof(buffer[0]),"\t<location file=\"%s\" line=\"%d\"/>\n", filename, line);
+    output = concat(output, buffer);
+    output = concat(output, indent(reporter));
+    output = concat(output, "</error>\n");
+    fputs(output, child_output_tmpfile);
 }
 
 

--- a/tests/xml_reporter_tests.c
+++ b/tests/xml_reporter_tests.c
@@ -155,6 +155,18 @@ Ensure(XmlReporter, will_report_non_finishing_test) {
     assert_that(output, contains_string("message=\"message\""));
 }
 
+Ensure(XmlReporter, will_report_time_correctly_for_non_finishing_test) {
+    const int line = 666;
+
+    reporter->start_suite(reporter, "suite_name", 1);
+    reporter->start_test(reporter, "test_name");
+    send_reporter_exception_notification(reporter);
+    reporter->finish_test(reporter, "filename", line, "message");
+    reporter->finish_suite(reporter, "filename", line);
+
+    assert_that(output, contains_string("name=\"test_name\" time=\""));
+}
+
 
 TestSuite *xml_reporter_tests(void) {
     TestSuite *suite = create_test_suite();
@@ -166,6 +178,7 @@ TestSuite *xml_reporter_tests(void) {
     add_test_with_context(suite, XmlReporter, will_mark_ignored_test_as_skipped);
     add_test_with_context(suite, XmlReporter, will_report_finishing_of_suite);
     add_test_with_context(suite, XmlReporter, will_report_non_finishing_test);
+    add_test_with_context(suite, XmlReporter, will_report_time_correctly_for_non_finishing_test);
 
     set_teardown(suite, teardown_xml_reporter_tests);
     return suite;


### PR DESCRIPTION
Change logic for reporting incomplete tests to align with reporting
passing or failing tests. That is store report in temp output file
and dump it to results in xml_report_finish_test when calling
transfer_output_from method.
This way the test time is reported in the correct place on the testcase
tag