### PR TITLE
Use git rev-parse to find git directory

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -48,6 +48,22 @@ include(DefineCPackConfig)
 include(MacroAddPlugin)
 include(MacroCopyFile)
 
+# Generate gitrevision.h if Git is available and the .git directory is found.
+find_program(GIT_EXECUTABLE git DOC "Git version control")
+mark_as_advanced(GIT_EXECUTABLE)
+
+# Find path to .git/logs/HEAD so that the gitrevision.h generation will only
+# happen on new commits. This is done from $PROJECT_SOURCE_DIR because git rev-parse
+# doesn't always return an absolute path so need to use get_filename_component()
+# to get a cross-platform `readlink -f $(git rev-parse --git-path logs/HEAD)`
+execute_process(
+  COMMAND ${GIT_EXECUTABLE} rev-parse --git-path logs/HEAD
+  WORKING_DIRECTORY "${PROJECT_SOURCE_DIR}"
+  OUTPUT_VARIABLE GITDIR
+  OUTPUT_STRIP_TRAILING_WHITESPACE
+  )
+get_filename_component(GITDIR "${GITDIR}" ABSOLUTE)
+
 # config.h checks
 include(ConfigureChecks.cmake)
 configure_file(config.h.cmake ${CMAKE_CURRENT_BINARY_DIR}/config.h)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,23 +1,21 @@
-# Generate gitrevision.h if Git is available
-# and the .git directory is present
-find_program(GIT_SCM git DOC "Git version control")
-mark_as_advanced(GIT_SCM)
-find_file(GITDIR NAMES .git PATHS ${PROJECT_SOURCE_DIR} NO_DEFAULT_PATH)
-if (GIT_SCM AND GITDIR)
+# Generate gitrevision.h if Git is available and the .git directory is found.
+# NOTE: $GITDIR is determined in top-level CMakeLists.txt
+if (GITDIR)
   # Create gitrevision.h
-  # that depends on the Git HEAD log
   add_custom_command(OUTPUT ${PROJECT_SOURCE_DIR}/gitrevision.h
     COMMAND ${CMAKE_COMMAND} -E echo_append "#define GITREVISION \"" > ${PROJECT_SOURCE_DIR}/gitrevision.h.tmp
-    COMMAND ${GIT_SCM} describe --tags --always --abbrev=7 --dirty=-modified >> ${PROJECT_SOURCE_DIR}/gitrevision.h.tmp
+    COMMAND ${GIT_EXECUTABLE} describe --tags --always --abbrev=7 --dirty=-modified >> ${PROJECT_SOURCE_DIR}/gitrevision.h.tmp
     COMMAND ${CMAKE_COMMAND} -E echo_append "\"" >> ${PROJECT_SOURCE_DIR}/gitrevision.h.tmp
     COMMAND sed -e N -e "s/\\n//g" ${PROJECT_SOURCE_DIR}/gitrevision.h.tmp > ${PROJECT_SOURCE_DIR}/gitrevision.h
     COMMAND ${CMAKE_COMMAND} -E remove -f ${PROJECT_SOURCE_DIR}/gitrevision.h.tmp
-    DEPENDS ${GITDIR}/logs/HEAD
+    DEPENDS ${GITDIR}
     VERBATIM
+    COMMENT "-- Generating gitrevision.h"
     )
 else()
   # No version control
   # e.g. when the software is built from a source tarball
+  message(WARNING "-- Unable to find git. Setting git revision to 'unknown'.")
   add_custom_command(OUTPUT ${PROJECT_SOURCE_DIR}/gitrevision.h
     COMMAND ${CMAKE_COMMAND} -E echo "#define GITREVISION \"unknown\"" > ${PROJECT_SOURCE_DIR}/gitrevision.h
     VERBATIM


### PR DESCRIPTION
The gitrevision.h header is updated when a new commit is made. New
commits are detected by adding a cmake dependency on the logs/HEAD file
in the .git directory. Unfortunately, submodules do not have a .git
directory (it is a file with the path to the parent's git directory).
So instead ask git where the .git directory is via git rev-parse.

The determination of the .git directory is split from the file
generation command because git rev-parse's behavior is not consistent
across versions of git and between being called from a submodule or a
top-level repository. To get around this, we want to do a cross-platform
equivalent to `readlink -f $(git rev-parse --git-path logs/HEAD)`, which
in cmake parlance is get_filename_component(<PATH> ABSOLUTE). This needs
to be done from $PROJECT_SOURCE_DIR for consistency. Additionally,
add_custom_command() is run at build time rather than cmake configuration
time, which is when add_library() is done. I'm not sure why, but cmake
appears requires add_custom_command() to be in the same CMakeLists.txt
file as the add_library() call that has gitrevision.h as a source
dependency.

In short, with this change cgreen can now be configured as a top-level
repo with an in-source or out-of-source build as well as a submodule
again with either an in-source or out-of-source build.