### PR TITLE
fix spelling-error

### DIFF
--- a/doc/man/man1/cgreen-runner.1
+++ b/doc/man/man1/cgreen-runner.1
@@ -26,7 +26,7 @@ shared dynamically loadable \fILIBRARY\fR you can auto-discover and
 run all tests using the
 .B cgreen-runner
 without having to manually add each and every test that you write to a
-suite programatically.
+suite programmatically.
 .PP
 This makes the TDD cycle even faster and less error-prone, one less thing to remember.
 

--- a/src/posix_runner_platform.c
+++ b/src/posix_runner_platform.c
@@ -80,7 +80,7 @@ static int wait_for_child_process(void) {
 void die_in(unsigned int seconds) {
     sighandler_t signal_result = signal(SIGALRM, (sighandler_t)&stop);
     if (SIG_ERR == signal_result) {
-        fprintf(stderr, "could not set alarm signal hander\n");
+        fprintf(stderr, "could not set alarm signal handler\n");
         return;
     }
 

--- a/src/win32_runner_platform.c
+++ b/src/win32_runner_platform.c
@@ -29,7 +29,7 @@ static void CALLBACK stop(UINT uTimerID, UINT uMsg, DWORD_PTR dwUser, DWORD_PTR 
 void die_in(unsigned int seconds) {
     MMRESULT signal_result = timeSetEvent(seconds*SECOND,SECOND,&stop,0,TIME_ONESHOT);
     if (0 == signal_result){
-        fprintf(stderr, "could not set alarm signal hander\n");
+        fprintf(stderr, "could not set alarm signal handler\n");
         return;
     }
 }


### PR DESCRIPTION
fix lintian error in debian packaging :
spelling-error-in-binary  hander handler
spelling-error-in-manpage programatically programmatically