### PR TITLE
Fix build error when build environment has no git command

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,6 +1,6 @@
 # Generate gitrevision.h if Git is available and the .git directory is found.
 # NOTE: $GITDIR is determined in top-level CMakeLists.txt
-if (GITDIR)
+if (GITDIR AND GIT_EXECUTABLE)
   # Create gitrevision.h
   add_custom_command(OUTPUT ${PROJECT_SOURCE_DIR}/gitrevision.h
     COMMAND ${CMAKE_COMMAND} -E echo_append "#define GITREVISION \"" > ${PROJECT_SOURCE_DIR}/gitrevision.h.tmp


### PR DESCRIPTION
Hello,
I found cgreen can not be built if no git command in build environment.
I fix it and here is the patch :)

Alvin