### PR TITLE
fix double-free in tcache2 error

### DIFF
--- a/tests/message_formatting_tests.c
+++ b/tests/message_formatting_tests.c
@@ -41,7 +41,6 @@ Ensure(MessageFormatting, shows_offset_as_zero_based) {
     assert_that(failure_message, contains_string("0x0b"));
     assert_that(strstr(failure_message, "0x0a"), is_less_than(strstr(failure_message, "0x0b")));
 
-    constraint->destroy(constraint);
     free(failure_message);
     destroy_constraint(constraint);
 }


### PR DESCRIPTION
Fix double-free error if glibc >=2.29