### PR TITLE
Add shebang for cgreen-debug script

### DIFF
--- a/tools/cgreen-debug
+++ b/tools/cgreen-debug
@@ -1,3 +1,4 @@
+#!/usr/bin/bash
 # cgreen-debug
 #
 # Script to start cgreen-runner under gdb, load a library and break


### PR DESCRIPTION
Looks like `cgreen-debug` doesn't have shebang that causes #212 issue.
It also leads to the warning in `rpmlint`:
```console
cgreen-runner.x86_64: E: script-without-shebang /usr/bin/cgreen-debug
```

This change adds shebang.

Closes #212