### PR TITLE
Add cgreen-debug man page

### DIFF
--- a/doc/man/man1/cgreen-debug.1
+++ b/doc/man/man1/cgreen-debug.1
@@ -1,14 +1,22 @@
 .TH CGREEN-DEBUG "1" "May 2020" "cgreen 1.2.0" "User Commands"
+
 .SH NAME
 cgreen-debug \- start cgreen-runner under GDB and break at a specific test
+
 .SH SYNOPSIS
 .B cgreen\-debug
 [\fI\,OPTION\/\fR...]
 \fILIBRARY\fR \fITEST\fR
+
+
 .SH DESCRIPTION
 .B cgreen-debug
-is a script to start cgreen-runner under gdb, load a \fILIBRARY\fR and break
-on a named \fITEST\fR.
+is a script to start cgreen-runner under gdb, load a \fILIBRARY\fR and break on
+a named \fITEST\fR.  Where \fILIBRARY\fR is a filename of the shared library of
+Cgreen tests, usually .so or .dll depending on your platform. \fITEST\fR is the
+name of a test in that library in the format <context>:<test_name>.
+
+.SS OPTIONS
 .TP
 .B "\-h, \-\-help"
 Print some usage information and exit.
@@ -26,5 +34,5 @@ is in the
 .B Cgreen
 manual available at
 .UR https://\:cgreen-devs.github.io/
-GitHub 
+GitHub
 .UE .

--- a/doc/man/man1/cgreen-debug.1
+++ b/doc/man/man1/cgreen-debug.1
@@ -1,0 +1,30 @@
+.TH CGREEN-DEBUG "1" "May 2020" "cgreen 1.2.0" "User Commands"
+.SH NAME
+cgreen-debug \- start cgreen-runner under GDB and break at a specific test
+.SH SYNOPSIS
+.B cgreen\-debug
+[\fI\,OPTION\/\fR...]
+\fILIBRARY\fR \fITEST\fR
+.SH DESCRIPTION
+.B cgreen-debug
+is a script to start cgreen-runner under gdb, load a \fILIBRARY\fR and break
+on a named \fITEST\fR.
+.TP
+.B "\-h, \-\-help"
+Print some usage information and exit.
+
+.SH "SEE ALSO"
+cgreen(5)
+cgreen-runner(1)
+
+.PP
+The full documentation for
+.B cgreen-debug
+and
+.B the Cgreen framework
+is in the
+.B Cgreen
+manual available at
+.UR https://\:cgreen-devs.github.io/
+GitHub 
+.UE .


### PR DESCRIPTION
This pull request adds a simple man page for `cgreen-debug` script. 

I guess It might be not really useful right now because it is just an adaptation of `help2man` output format.
Unfortunately, I can't add more info in it because I'm not native English speaker :)

Rendered it looks like this:
```console
CGREEN-DEBUG(1)                  User Commands                 CGREEN-DEBUG(1)

NAME
       cgreen-debug  -  start  cgreen-runner under GDB and break at a specific
       test

SYNOPSIS
       cgreen-debug [OPTION...]  LIBRARY TEST

DESCRIPTION
       cgreen-debug is a script to  start  cgreen-runner  under  gdb,  load  a
       LIBRARY and break on a named TEST.

       -h, --help
              Print some usage information and exit.

SEE ALSO
       cgreen(5)

       The  full documentation for cgreen-debug and the Cgreen framework is in
       the Cgreen manual available at GitHub ⟨https://cgreen-devs.github.io/⟩.

cgreen 1.2.0                       May 2020                    CGREEN-DEBUG(1)
```

Closes #221 