### PR TITLE
Fix for_is_equal_to_hex test on ARM

### DIFF
--- a/tests/constraint_messages_tests.c
+++ b/tests/constraint_messages_tests.c
@@ -37,7 +37,7 @@ Ensure(ConstraintMessage,for_is_equal_to) {
 }
 
 Ensure(ConstraintMessage, for_is_equal_to_hex) {
-    char chars[4];
+    signed char chars[4];
     memset(chars, 0xaa, sizeof(chars));
     assert_that(chars[0], is_equal_to_hex(0xbb));
 }


### PR DESCRIPTION
It seems char type on ARM platforms is unsigned by default, which causes
the test to fail. It looks like it is better to fully specify the char type to not
depend on the target architecture.

Closes #223 