### PR TITLE
Update gopt to v10.0

### DIFF
--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -1,7 +1,7 @@
 include_directories(${CGREEN_PUBLIC_INCLUDE_DIRS} ${PROJECT_BINARY_DIR})
 
 set(RUNNER_SRCS
-    cgreen-runner.c gopt.c runner.c discoverer.c test_item.c io.c)
+    cgreen-runner.c gopt.c gopt-errors.c runner.c discoverer.c test_item.c io.c)
 set_source_files_properties(${RUNNER_SRCS} PROPERTIES LANGUAGE C)
 
 add_executable(cgreen-runner ${RUNNER_SRCS})

--- a/tools/gopt-errors.c
+++ b/tools/gopt-errors.c
@@ -1,0 +1,86 @@
+/* gopt-errors.c   PUBILC DOMAIN 2015   t.gopt@purposeful.co.uk */
+
+/* <http:///www.purposeful.co.uk/software/gopt> */
+
+/*
+  I, Tom Vajzovic, am the author of this software and its documentation.
+  I permanently abandon all intellectual property rights in them, including
+  copyright, trademarks, design rights, database right, patents, and the right
+  to be identified as the author.
+
+  I am fairly certain that the software does what the documentation says it
+  does, but I do not guarantee that it does, or that it does what you think it
+  should.  I do not guarantee that it will not have undesirable side effects.
+
+  You are free to use, modify and distribute this software as you please, but
+  you do so at your own risk.  If you do not pass on this warning then you may
+  be responsible for any problems encountered by those who obtain the software
+  through you.
+*/
+
+#include <stdlib.h>
+#include <stdio.h>
+
+#ifdef _BSD_SOURCE
+#include <sysexits.h>
+#else
+#define EX_USAGE EXIT_FAILURE
+#endif
+
+#include "gopt.h"
+
+void gopt_errors (const char *argv0, const struct option *options)
+{
+  unsigned int bad_option_index = 0;
+  unsigned int i;
+
+  while (!(options[bad_option_index].flags & GOPT_LAST))
+  {
+    bad_option_index++;
+  }
+
+  if (options[bad_option_index].short_name)
+  {
+    fprintf (stderr, "%s: unrecognised option -%c\n", argv0, options[bad_option_index].short_name);
+    exit (EX_USAGE);
+  }
+
+  if (options[bad_option_index].long_name)
+  {
+    fprintf (stderr, "%s: unrecognised option --%s\n", argv0, options[bad_option_index].long_name);
+    exit (EX_USAGE);
+  }
+
+  for (i = 0; i < bad_option_index; i++)
+  {
+    if ((options[i].flags & GOPT_SEEN_SHORT_WITHOUT) && (options[i].flags & GOPT_ARGUMENT_REQUIRED))
+    {
+      fprintf (stderr, "%s: option -%c requires an option-argument\n", argv0, options[i].short_name);
+      exit (EX_USAGE);
+    }
+
+    if ((options[i].flags & GOPT_SEEN_SHORT_WITH) && (options[i].flags & GOPT_ARGUMENT_FORBIDDEN))
+    {
+      fprintf (stderr, "%s: option -%c must not have an option-argument\n", argv0, options[i].short_name);
+      exit (EX_USAGE);
+    }
+
+    if ((options[i].flags & GOPT_SEEN_LONG_WITHOUT) && (options[i].flags & GOPT_ARGUMENT_REQUIRED))
+    {
+      fprintf (stderr, "%s: option --%s requires an option-argument\n", argv0, options[i].long_name);
+      exit (EX_USAGE);
+    }
+
+    if ((options[i].flags & GOPT_SEEN_LONG_WITH) && (options[i].flags & GOPT_ARGUMENT_FORBIDDEN))
+    {
+      fprintf (stderr, "%s: option --%s must not have an option-argument\n", argv0, options[i].long_name);
+      exit (EX_USAGE);
+    }
+
+    if ((options[i].count > 1) && !(options[i].flags & GOPT_REPEATABLE))
+    {
+      fprintf (stderr, "%s: option -%c/--%s may not be repeated\n", argv0, options[i].short_name, options[i].long_name);
+      exit (EX_USAGE);
+    }
+  }
+}

--- a/tools/gopt.h
+++ b/tools/gopt.h
@@ -1,62 +1,143 @@
-/* gopt.h version 8.1: tom.viza@gmail.com PUBLIC DOMAIN 2003-8 */
+/* gopt.h   PUBILC DOMAIN 2015   t.gopt@purposeful.co.uk */
+
+/* <http:///www.purposeful.co.uk/software/gopt> */
+
 /*
-I, Tom Vajzovic, am the author of this software and its documentation and
-permanently abandon all copyright and other intellectual property rights in
-them, including the right to be identified as the author.
+  I, Tom Vajzovic, am the author of this software and its documentation.
+  I permanently abandon all intellectual property rights in them, including
+  copyright, trademarks, design rights, database right, patents, and the right
+  to be identified as the author.
 
-I am fairly certain that this software does what the documentation says it
-does, but I cannot guarantee that it does, or that it does what you think it
-should, and I cannot guarantee that it will not have undesirable side effects.
+  I am fairly certain that the software does what the documentation says it
+  does, but I do not guarantee that it does, or that it does what you think it
+  should.  I do not guarantee that it will not have undesirable side effects.
 
-You are free to use, modify and distribute this software as you please, but
-you do so at your own risk.  If you remove or hide this warning then you are
-responsible for any problems encountered by people that you make the software
-available to.
-
-Before modifying or distributing this software I ask that you would please
-read http://www.purposeful.co.uk/tfl/
+  You are free to use, modify and distribute this software as you please, but
+  you do so at your own risk.  If you do not pass on this warning then you may
+  be responsible for any problems encountered by those who obtain the software
+  through you.
 */
 
 #ifndef GOPT_H_INCLUDED
 #define GOPT_H_INCLUDED
 
-#define GOPT_ONCE   0
-#define GOPT_REPEAT 1
-#define GOPT_NOARG  0
-#define GOPT_ARG    2
+#ifdef __cplusplus
+extern "C" {
+#endif
 
-struct gopt_option_spec { int key; int flags; const char *shortname; const char*const*longname; };
+struct option
+{
+  /* input: */
+  char          short_name;
+  const char   *long_name;
 
-#define gopt_start(...)  (const void*)(const struct gopt_option_spec []){ __VA_ARGS__, {0, 0, 0, 0}}
-#define gopt_option(key,flags,shortname,longname)    { key, flags, shortname, longname }
-#define gopt_shorts( ... )      (const char*)(const char[]){ __VA_ARGS__, 0 }
-#define gopt_longs( ... )       (const char**)(const char*[]){ __VA_ARGS__, NULL }
+  /* input/output: */
+  unsigned int  flags;
 
+  /* output: */
+  unsigned int  count;
+  char         *argument;
+};
 
-void *gopt_sort( int *argc, const char **argv, const void *opt_specs );
-/* returns a pointer for use in the following calls
- * prints to stderr and call exit() on error
- */
-size_t gopt( const void *opts, int key );
-/* returns the number of times the option was specified
- * which will be 0 or 1 unless GOPT_REPEAT was used
- */
-size_t gopt_arg( const void *opts, int key, const char **arg );
-/* returns the number of times the option was specified
- * writes a pointer to the option argument from the first (or only) occurance to *arg
- */
-const char *gopt_arg_i( const void *opts, int key, size_t i );
-/* returns a pointer to the ith (starting at zero) occurance
- * of the option, or NULL if it was not specified that many times
- */
-size_t gopt_args( const void *opts, int key, const char **args, size_t args_len );
-/* returns the number of times the option was specified
- * writes pointers to the option arguments in the order of occurance to args[].
- * writes at most args_len pointers
- * if the return value is less than args_len, also writes a null pointer
- */
-void gopt_free( void *opts );
-/* releases memory allocated in the corresponding call to gopt_sort()
- * opts can no longer be used 
- */
+/* values for flags: */
+#define GOPT_ARGUMENT_OPTIONAL  0x000u /* option may or may not have an option-argument */
+#define GOPT_ARGUMENT_FORBIDDEN 0x001u /* option must not have an option-argument */
+#define GOPT_ARGUMENT_REQUIRED  0x002u /* option must have an option-argument */
+#define GOPT_ARGUMENT_NO_HYPHEN 0x004u /* option-argument may not start with hyphen/minus */
+#define GOPT_REPEATABLE         0x008u /* option may be specified more than once */
+#define GOPT_SEEN_SHORT_WITHOUT 0x010u /* short form of option was present without an option-argument in argv */
+#define GOPT_SEEN_SHORT_WITH    0x020u /* short form of option was present with an option-argument in argv */
+#define GOPT_SEEN_LONG_WITHOUT  0x040u /* long form of option was present without an option-argument in argv */
+#define GOPT_SEEN_LONG_WITH     0x080u /* long form of option was present with an option-argument in argv */
+#define GOPT_LAST               0x100u /* this is the last element of the array */
+
+int gopt (char **argv, struct option *options);
+/*
+  The function gopt() takes an argument vector argv, which has the same
+  form as the second argument to main().  It removes from the vector all
+  options and option-arguments, leaving only the program name, the
+  operands and a null pointer at the end.  It returns the updated
+  argument count argc.  It does not need to know the initial value of
+  argc because the input vector must be null-terminated.
+
+  It also takes an array of struct option, the elements of which are
+  used for specifying the options which are to be recognized and for
+  returning details of which options were present in the argument
+  vector.
+
+  The members of struct option are used as follows:
+
+  On input, short_name is the single character that follows "-" to make
+  a short option, or zero if there is no short form of this option.
+
+  On input, long_name is the name of the long option excluding the "--",
+  or NULL if there is no long form of this option.
+
+  On return short_name and long_name are unaltered.
+
+  count may be uninitialized on input.  On return it is set to the
+  number of times the option was specified.  If the option is not
+  present, this is zero.  If an option has both a short and long name,
+  this is the sum of counts for both forms.
+
+  argument may be uninitialized on input.  On return it is set to the
+  last option-argument specified to this option, or NULL if no
+  option-argument was specified with the last occurrence of this
+  option, or the option was never specified.
+
+  flags is the bitwise-or of certain constants.  On input flags must
+  contain exactly one of:
+  GOPT_ARGUMENT_FORBIDDEN if the option does not take an option-argument
+  GOPT_ARGUMENT_REQUIRED if it always requires an option-argument
+  GOPT_ARGUMENT_OPTIONAL if it may or may not take an option-argument
+
+  If flags contains GOPT_ARGUMENT_REQUIRED, it may also contain
+  GOPT_ARGUMENT_NO_HYPHEN.  If the option argument is not allowed to
+  start with a '-', but the next member of the argument vector does
+  start with one where an option argument was expected, then this flag
+  causes it to be interpreted as another option, leaving the argument
+  to the preceding option NULL.  The application can then detect the
+  NULL and give an error message like "missing option argument" which
+  may be preferable to treating the next program argument as an option
+  argument and then giving a less helpful message when the option
+  argument is found to be invalid.
+
+  flags may also optionally contain GOPT_REPEATABLE.  This is ignored
+  by the option parsing code, but may be used when checking the value
+  returned in count, where if this flag is specified then the
+  application will presumably report an error if count is greater than
+  one.
+
+  On return, the initial value of flags is still present, and
+  additionally GOPT_SEEN_SHORT_WITH and/or GOPT_SEEN_SHORT_WITHOUT are
+  set if the short name was used at least once with or without an
+  option-argument, respectively, and GOPT_SEEN_LONG_WITH and/or
+  GOPT_SEEN_LONG_WITHOUT are set if the long name was used.
+
+  On input there must be zero or more elements in the options array
+  initialized as above.  These must be followed by one element where
+  flags is exactly GOPT_LAST.  All other members of this element may be
+  uninitialized on input.  On return the count member of this element
+  will be set to the total number of unrecognized options present.
+  The short_name member will be set to the first unrecognized short
+  option, or zero if there were none.  The long_name will be set to
+  point to the start of the name of the first unrecognized long option,
+  or NULL if there were none.  For completeness the argument member
+  will be set to the option argument of the last unrecognized option
+  (the same as with other options) but this is probably useless to the
+  application.
+*/
+
+void gopt_errors (const char *argv0, const struct option *options);
+/*
+  The function gopt_errors() examines the array of struct option
+  after it has been filled out by gopt().  If the options specified
+  were invalid it prints an error message starting with argv0 and
+  terminates the program.
+*/
+
+#ifdef __cplusplus
+}
+#endif
+
 #endif /* GOPT_H_INCLUDED */


### PR DESCRIPTION
This merge request replaces `gopt` by the latest version.
Closes #229 

Tested with:
Apple clang version 11.0.3 (clang-1103.0.32.59)
Target: x86_64-apple-darwin19.4.0
New `gopt` doesn't have arithmetic on a null pointer, so it also closes #205 