### PR TITLE
fix unittest issue on arch-s390x

### DIFF
--- a/tests/constraint_messages_tests.c
+++ b/tests/constraint_messages_tests.c
@@ -39,7 +39,7 @@ Ensure(ConstraintMessage,for_is_equal_to) {
 Ensure(ConstraintMessage, for_is_equal_to_hex) {
     unsigned char bytes[4];
     memset(bytes, 0xaa, sizeof(bytes));
-    assert_that(bytes[0], is_equal_to_hex(0xbb));
+    assert_that((unsigned char) bytes[0], is_equal_to_hex(0xbb));
 }
 
 Ensure(ConstraintMessage, for_is_not_equal_to) {
@@ -60,8 +60,8 @@ Ensure(ConstraintMessage, for_is_less_than) {
 
 // Contents of struct/memory
 Ensure(ConstraintMessage, for_is_equal_to_contents_of) {
-    int forty_five[45] = {45, 44, 43}, thirty_three[33] = {45, 44, 33};
-    assert_that(thirty_three, is_equal_to_contents_of(forty_five, 55));
+    char forty_five[45] = {45, 44, 43}, thirty_three[33] = {45, 44, 33};
+    assert_that(thirty_three, is_equal_to_contents_of(forty_five, 45));
 }
 
 Ensure(ConstraintMessage, for_is_not_equal_to_contents_of) {

--- a/tests/constraint_messages_tests.expected
+++ b/tests/constraint_messages_tests.expected
@@ -52,7 +52,7 @@ constraint_messages_tests.c: Failure: ConstraintMessage -> for_is_equal_to
 
 constraint_messages_tests.c: Failure: ConstraintMessage -> for_is_equal_to_contents_of 
 	Expected [thirty_three] to [equal contents of] [forty_five]
-		at offset:			[8]
+		at offset:			[2]
 			actual value:		[0x21]
 			expected value:		[0x2b]
 
@@ -62,7 +62,7 @@ constraint_messages_tests.c: Failure: ConstraintMessage -> for_is_equal_to_doubl
 		expected value:			[3.300000]
 
 constraint_messages_tests.c: Failure: ConstraintMessage -> for_is_equal_to_hex 
-	Expected [bytes[0]] to [equal] [0xbb]
+	Expected [(unsigned char) bytes[0]] to [equal] [0xbb]
 		actual value:			[0xaa]
 		expected value:			[0xbb]
 

--- a/tests/custom_constraint_messages_tests.c
+++ b/tests/custom_constraint_messages_tests.c
@@ -82,12 +82,12 @@ Ensure(CustomConstraint, custom_constraint_using_a_function_with_arguments_funct
 
 */
 typedef struct Box {
-    int id;
+    char id;
     int size;
 } Box;
 
 typedef struct Piece {
-    int id;
+    char id;
     int size;
 } Piece;
 
@@ -127,7 +127,7 @@ Constraint *create_piece_fit_in_box_constraint(intptr_t expected_value, const ch
 #define can_fit_in_box(box) create_piece_fit_in_box_constraint((intptr_t)box, #box)
 
 Ensure(CustomConstraint, more_complex_custom_constraint_function) {
-    Box box1 = {.id = 1, .size = 5};
-    Piece piece99 = {.id = 99, .size = 6};
+    Box box1 = {.id = (char)1, .size = 5};
+    Piece piece99 = {.id = (char)99, .size = 6};
     assert_that(&piece99, can_fit_in_box(&box1));
 }


### PR DESCRIPTION
  * fix endian issue of tests.  #226 #227 
    - is_equal_to_* is not able to handle compare variables correctly on big-endian architecture. However it is still 
      capable to work well while comparing on a one-byte basis.    