### PR TITLE
Add cgreen namespace to fix legacy.h for C++.

### DIFF
--- a/include/cgreen/legacy.h
+++ b/include/cgreen/legacy.h
@@ -3,8 +3,43 @@
 
 #include "internal/stringify_token.h"
 
+#ifdef __cplusplus
+/* Legacy style asserts (for C++):*/
+#define assert_true(result) \
+        (*cgreen::get_test_reporter()->assert_true)(cgreen::get_test_reporter(), __FILE__, __LINE__, (result), "[" STRINGIFY_TOKEN(result) "] should be true\n", NULL)
+#define assert_false(result) \
+        (*cgreen::get_test_reporter()->assert_true)(cgreen::get_test_reporter(), __FILE__, __LINE__, ! (result), "[" STRINGIFY_TOKEN(result) "] should be false\n", NULL)
+#define assert_equal(tried, expected) \
+        assert_equal_(__FILE__, __LINE__, STRINGIFY_TOKEN(tried), (intptr_t)(tried), (intptr_t)(expected))
+#define assert_not_equal(tried, expected) \
+        assert_not_equal_(__FILE__, __LINE__, STRINGIFY_TOKEN(tried), (intptr_t)(tried), (intptr_t)(expected))
+#define assert_double_equal(tried, expected) \
+        assert_double_equal_(__FILE__, __LINE__, STRINGIFY_TOKEN(tried), (tried), (expected))
+#define assert_double_not_equal(tried, expected) \
+        assert_double_not_equal_(__FILE__, __LINE__, STRINGIFY_TOKEN(tried), (tried), (expected))
+#define assert_string_equal(tried, expected) \
+        assert_string_equal_(__FILE__, __LINE__, STRINGIFY_TOKEN(tried), (tried), (expected))
+#define assert_string_not_equal(tried, expected) \
+        assert_string_not_equal_(__FILE__, __LINE__, STRINGIFY_TOKEN(tried), (tried), (expected))
 
-/* Legacy style asserts:*/
+#define assert_true_with_message(result, ...) \
+        (*cgreen::get_test_reporter()->assert_true)(cgreen::get_test_reporter(), __FILE__, __LINE__, (result), __VA_ARGS__)
+#define assert_false_with_message(result, ...) \
+        (*cgreen::get_test_reporter()->assert_true)(cgreen::get_test_reporter(), __FILE__, __LINE__, ! (result), __VA_ARGS__)
+#define assert_equal_with_message(tried, expected, ...) \
+        (*cgreen::get_test_reporter()->assert_true)(cgreen::get_test_reporter(), __FILE__, __LINE__, ((tried) == (expected)), __VA_ARGS__)
+#define assert_not_equal_with_message(tried, expected, ...) \
+        (*cgreen::get_test_reporter()->assert_true)(cgreen::get_test_reporter(), __FILE__, __LINE__, ((tried) != (expected)), __VA_ARGS__)
+#define assert_double_equal_with_message(tried, expected, ...) \
+        (*cgreen::get_test_reporter()->assert_true)(cgreen::get_test_reporter(), __FILE__, __LINE__, doubles_are_equal((tried), (expected)), __VA_ARGS__)
+#define assert_double_not_equal_with_message(tried, expected, ...) \
+        (*cgreen::get_test_reporter()->assert_true)(cgreen::get_test_reporter(), __FILE__, __LINE__, doubles_are_equal((tried), (expected)), __VA_ARGS__)
+#define assert_string_equal_with_message(tried, expected, ...) \
+        (*cgreen::get_test_reporter()->assert_true)(cgreen::get_test_reporter(), __FILE__, __LINE__, strings_are_equal((tried), (expected)), __VA_ARGS__)
+#define assert_string_not_equal_with_message(tried, expected, ...) \
+        (*cgreen::get_test_reporter()->assert_true)(cgreen::get_test_reporter(), __FILE__, __LINE__, !strings_are_equal((tried), (expected)), __VA_ARGS__)
+#else
+/* Legacy style asserts (for C):*/
 #define assert_true(result) \
         (*get_test_reporter()->assert_true)(get_test_reporter(), __FILE__, __LINE__, (result), "[" STRINGIFY_TOKEN(result) "] should be true\n", NULL)
 #define assert_false(result) \
@@ -38,5 +73,6 @@
         (*get_test_reporter()->assert_true)(get_test_reporter(), __FILE__, __LINE__, strings_are_equal((tried), (expected)), __VA_ARGS__)
 #define assert_string_not_equal_with_message(tried, expected, ...) \
         (*get_test_reporter()->assert_true)(get_test_reporter(), __FILE__, __LINE__, !strings_are_equal((tried), (expected)), __VA_ARGS__)
+#endif
 
 #endif


### PR DESCRIPTION
Hello,

Using cgreen for C++ without including "using namespace cgreen" in the code results in compilation errors when one attempts to use "assert_throws()".

I just added a macro conditional block that checks if C++ is being used, and if it is, adds the cgreen namespace ("cgreen::" in front of "get_test_reporter()").

Those who are applying "using namespace cgreen" to get around the compilation error should see no difference.