### PR TITLE
[doc] Update expect_never -> never_expect in doc

### DIFF
--- a/doc/tutorial_src/side_effect.c
+++ b/doc/tutorial_src/side_effect.c
@@ -37,7 +37,7 @@ Ensure(using_side_effect) {
                   will_return(EOF),
                   with_side_effect(&update_counter,
                                   &number_of_times_reader_was_called));
-    expect_never(writer);
+    never_expect(writer);
     by_paragraph(&reader, NULL, &writer, NULL);
 
     assert_that(number_of_times_reader_was_called, is_equal_to(1));


### PR DESCRIPTION
One of the files in the tutorial had the old version of the never_expect function (expect_never), which made the example not work. I have only changed the example file according to the new name of the function.