### PR TITLE
Fix #256 XML test reporter does not escape chars.

### DIFF
--- a/src/xml_reporter.c
+++ b/src/xml_reporter.c
@@ -193,14 +193,44 @@ static void xml_show_skip(TestReporter *reporter, const char *file, int line) {
     fputs(output, child_output_tmpfile);
 }
 
+static void xml_concat_escaped_message(const char *message, va_list arguments) {
+    char buffer[1000];
+    snprintf(buffer, sizeof(buffer)/sizeof(buffer[0]), message, arguments);
+
+    size_t current_char_position = 0;
+    for (; current_char_position < strlen(buffer); current_char_position++) {
+        switch (buffer[current_char_position]) {
+            case '"':
+                output = concat(output, "&quot;");
+                break;
+            case '&':
+                output = concat(output, "&amp;");
+                break;
+            case '<':
+                output = concat(output, "&lt;");
+                break;
+            case '>':
+                output = concat(output, "&gt;");
+                break;
+            case '\'':
+                output = concat(output, "&apos;");
+                break;
+            default: {
+                char single_char[2] = {0};
+                single_char[0] = buffer[current_char_position];
+                output = concat(output, single_char);
+            }
+        }
+    }
+}
+
 static void xml_show_fail(TestReporter *reporter, const char *file, int line, const char *message, va_list arguments) {
     char buffer[1000];
 
     output = concat(output, indent(reporter));
     output = concat(output, "<failure message=\"");
 
-    vsnprintf(buffer, sizeof(buffer)/sizeof(buffer[0]), message, arguments);
-    output = concat(output, buffer);
+    xml_concat_escaped_message(message, arguments);
     output = concat(output, "\">\n");
     output = concat(output, indent(reporter));
 

--- a/tests/xml_output_tests.c
+++ b/tests/xml_output_tests.c
@@ -1,4 +1,5 @@
 #include <cgreen/cgreen.h>
+#include <cgreen/constraint_syntax_helpers.h>
 
 Ensure(failing_test_is_listed_by_xml_reporter) {
     assert_that(false);
@@ -6,4 +7,15 @@ Ensure(failing_test_is_listed_by_xml_reporter) {
 
 Ensure(passing_test_is_listed_by_xml_reporter) {
     assert_that(true);
+}
+
+Ensure(error_message_gets_escaped_by_xml_reporter) {
+    char *test_string =
+        "<?xml version=\"1.0\" encoding=\"ISO-8859-1\" ?>\n"
+        "<example name=\"arbitrary xml content\">\n"
+        "    <content>I'm the content & have chars which have to be escaped, "
+        "if put in outer XML.</content>\n"
+        "</example>";
+    char *expected_string = "I'm not to be found!";
+    assert_that(test_string, contains_string(expected_string));
 }

--- a/tests/xml_output_tests.expected
+++ b/tests/xml_output_tests.expected
@@ -3,6 +3,16 @@
 </testsuite>
 <?xml version="1.0" encoding="ISO-8859-1" ?>
 	<testsuite name="xml_output_tests-default">
+		<testcase classname="xml_output_tests/default" name="error_message_gets_escaped_by_xml_reporter" time="0.00000">
+			<failure message="Expected [test_string] to [contain string] [expected_string]
+		actual value:			[&quot;&lt;?xml version=&quot;1.0&quot; encoding=&quot;ISO-8859-1&quot; ?&gt;
+&lt;example name=&quot;arbitrary xml content&quot;&gt;
+    &lt;content&gt;I&apos;m the content &amp; have chars which have to be escaped, if put in outer XML.&lt;/content&gt;
+&lt;/example&gt;&quot;]
+		expected to contain:		[&quot;I&apos;m not to be found!&quot;]">
+				<location file="xml_output_tests.c" line="0"/>
+			</failure>
+		</testcase>
 		<testcase classname="xml_output_tests/default" name="failing_test_is_listed_by_xml_reporter" time="0.00000">
 			<failure message="Expected [0] to [be true]">
 				<location file="xml_output_tests.c" line="0"/>


### PR DESCRIPTION
This fixes the issue, that the XML test reporter produces invalid
XML when string contraints are used and/or test strings contain
characters which have to be escaped: <, >, &, ' or "

Chars in fail messages are now getting replaced with the proper escape
sequences "&lt;", "&gt;", "&amp;", "&apos;" or "&quot;", resp.