### PR TITLE
Fix build on OpenBSD

### DIFF
--- a/cmake/Modules/DefineCompilerFlags.cmake
+++ b/cmake/Modules/DefineCompilerFlags.cmake
@@ -22,8 +22,10 @@ if (UNIX)
     endif (CGREEN_INTERNAL_WITH_GCOV)
 
     add_definitions(-D_REENTRANT)           # for gmtime_r()
-    add_definitions(-D_XOPEN_SOURCE)        # for popen() and pclose()
-    add_definitions(-D_XOPEN_SOURCE_EXTENDED) # for strdup(), which isn't part of C99
+    if (NOT ${CMAKE_SYSTEM_NAME} MATCHES ".*OpenBSD.*")
+      add_definitions(-D_XOPEN_SOURCE)        # for popen() and pclose()
+      add_definitions(-D_XOPEN_SOURCE_EXTENDED) # for strdup(), which isn't part of C99
+    endif()
     add_definitions(-D__STDC_FORMAT_MACROS) # for PRI*PTR format macros, required by C99
 
     if (NOT CYGWIN)

--- a/src/posix_cgreen_time.c
+++ b/src/posix_cgreen_time.c
@@ -8,7 +8,7 @@
 #endif // #ifdef __ANDROID__
 
 /* TODO: this should really be handle by CMake config... */
-#if defined(__FreeBSD__) || defined(__linux__) || defined(__APPLE__) || defined(__CYGWIN__)
+#if defined(__FreeBSD__) || defined(__linux__) || defined(__APPLE__) || defined(__CYGWIN__) || defined(__OpenBSD__)
 #  include <sys/time.h>
 #  define HAVE_GETTIMEOFDAY 1
 #else


### PR DESCRIPTION
OpenBSD enables the POSIX api by default, causing weird things to happen if _X_OPEN_SOURCE is enabled. <sys/time.h> is also required for gettimeofday() on OpenBSD as well.