### PR TITLE
Documenting the need for 'packaging' when using `cgreen-mocker`

### DIFF
--- a/contrib/cgreen-mocker/requirements.txt
+++ b/contrib/cgreen-mocker/requirements.txt
@@ -1,0 +1,3 @@
+pycparser
+packaging
+

--- a/doc/cgreen-guide-en.asciidoc
+++ b/doc/cgreen-guide-en.asciidoc
@@ -2993,11 +2993,16 @@ CgreenValue make_cgreen_string_value(const char *string) {
 
 Of course, you would pipe this output to a file.
 
-To use `cgreen-mocker` you need Python and `pycparser`.
-The latter can be found at [https://github.com/eliben/pycparser] or can easily be installed with
+To use `cgreen-mocker` you need Python, and the following packages:
+
+* `packaging` -- [https://github.com/pypa/packaging]
+
+* `pycparser` -- [https://github.com/eliben/pycparser]
+
+These can easily be installed with:
 
 ----------------
-$ pip install pycparser
+$ pip install -r requirements.txt
 ----------------
 
 NOTE: `cgreen-mocker` is an unsupported contribution to the *Cgreen*


### PR DESCRIPTION
## Issue

On my openSUSE Tumbleweed VM, the default Python distribution (3.8.11) does not have the `packaging` module by default inside of a `venv`:

```
avj@pika ~/clones/cgreen$ lsb_release --all
LSB Version:    n/a
Distributor ID: openSUSE
Description:    openSUSE Tumbleweed
Release:        20210902
Codename:       n/a
avj@pika ~/clones/cgreen$ python3 -m venv venv
avj@pika ~/clones/cgreen$ source venv/bin/activate
(venv) avj@pika ~/clones/cgreen$ python3 --version
Python 3.8.11
(venv) avj@pika ~/clones/cgreen$ echo "import packaging" | python3
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
ModuleNotFoundError: No module named 'packaging'
```

This means that you cannot run `cgreen-mocker`:

```
(venv) avj@pika ~/clones/cgreen$ python3 contrib/cgreen-mocker/cgreen-mocker.py
Traceback (most recent call last):
  File "contrib/cgreen-mocker/cgreen-mocker.py", line 44, in <module>
    from packaging import version
ModuleNotFoundError: No module named 'packaging'
```

## Resolution

This PR adds the need for the `packaging` module to the documentation for `cgreen-mocker.py`, as well as adding a `requirements.txt` that makes it easy to ensure you have the necessary prerequisites to run `cgreen-mocker.py`.

The provided `requirements.txt` is purposefully **unversioned** as the current installation steps are also unversioned.

The documentation has been updated to use `pip install -r requirements.txt` vs. installing packages explicitly using `pip`.

Signed-off-by: Andrew V. Jones <andrew.jones@vector.com>