### PR TITLE
Use correct asciidoc syntax

### DIFF
--- a/doc/cgreen-guide-en.asciidoc
+++ b/doc/cgreen-guide-en.asciidoc
@@ -2995,9 +2995,9 @@ Of course, you would pipe this output to a file.
 
 To use `cgreen-mocker` you need Python, and the following packages:
 
-* `packaging` -- [https://github.com/pypa/packaging]
+* `packaging` -- (https://github.com/pypa/packaging)
 
-* `pycparser` -- [https://github.com/eliben/pycparser]
+* `pycparser` -- (https://github.com/eliben/pycparser)
 
 These can easily be installed with:
 


### PR DESCRIPTION
In PR #276 I copied the existing asciidoc syntax without checking it; it had used markdown syntax for URLs, which isn't correct for asciidoc.

This PR corrects the asciidoc syntax such that the links appear correctly.

Sorry for missing this on the other PR.

Signed-off-by: Andrew V. Jones <andrew.jones@vector.com>