### PR TITLE
Add libxml2 as a dedicated report formatter

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,9 +30,9 @@ before_install:
 script:
   - mkdir -p build
   - cd build
-  - cmake -DCGREEN_WITH_UNIT_TESTS:BOOL=ON -DCGREEN_WITH_STATIC_LIBRARY:BOOL=$CGREEN_WITH_STATIC_LIBRARY -DCGREEN_INTERNAL_WITH_GCOV:BOOL=$WITH_GCOV ..
-  - make -j2
-  - ctest --output-on-failure
+  - cmake -DCGREEN_WITH_XML:BOOL=OFF -DCGREEN_WITH_LIBXML2:BOOL=OFF -DCGREEN_WITH_UNIT_TESTS:BOOL=ON -DCGREEN_WITH_STATIC_LIBRARY:BOOL=$CGREEN_WITH_STATIC_LIBRARY -DCGREEN_INTERNAL_WITH_GCOV:BOOL=OFF .. && make -j2 && ctest --output-on-failure
+  - rm -f CMakeCache.txt
+  - cmake -DCGREEN_WITH_UNIT_TESTS:BOOL=ON -DCGREEN_WITH_STATIC_LIBRARY:BOOL=$CGREEN_WITH_STATIC_LIBRARY -DCGREEN_INTERNAL_WITH_GCOV:BOOL=$WITH_GCOV .. && make -j2 && ctest --output-on-failure
 
 after_success:
   - if [ "$CC" = "gcc" ];

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,7 @@ addons:
     - lcov
     - g++
     - valgrind
+    - libxml2-dev
 
 before_install:
   - if [[ $CC == gcc ]] ; then export CXX=g++ ; else export CXX=clang++ ; fi

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,10 +10,13 @@ if (NOT(CMAKE_MAJOR_VERSION LESS 3) AND APPLE)
 endif()
 
 find_package (Threads)
-set(CGREEN_WITH_LIBXML2 OFF CACHE BOOL
+set(CGREEN_WITH_LIBXML2 ON CACHE BOOL
     "Add an XML report generator which uses libxml2 for output formatting")
 if (CGREEN_WITH_LIBXML2)
-find_package (LibXml2)
+  find_package (LibXml2)
+  if (NOT LibXml2_FOUND)
+    set(CGREEN_WITH_LIBXML2 OFF)
+  endif (NOT LibXml2_FOUND)
 endif (CGREEN_WITH_LIBXML2)
 
 enable_testing()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,6 +10,11 @@ if (NOT(CMAKE_MAJOR_VERSION LESS 3) AND APPLE)
 endif()
 
 find_package (Threads)
+set(CGREEN_WITH_LIBXML2 OFF CACHE BOOL
+    "Add an XML report generator which uses libxml2 for output formatting")
+if (CGREEN_WITH_LIBXML2)
+find_package (LibXml2)
+endif (CGREEN_WITH_LIBXML2)
 
 enable_testing()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,8 +10,12 @@ if (NOT(CMAKE_MAJOR_VERSION LESS 3) AND APPLE)
 endif()
 
 find_package (Threads)
+
+set(CGREEN_WITH_XML ON CACHE BOOL
+    "Add a simple XML report generator without external dependencies")
 set(CGREEN_WITH_LIBXML2 ON CACHE BOOL
     "Add an XML report generator which uses libxml2 for output formatting")
+
 if (CGREEN_WITH_LIBXML2)
   find_package (LibXml2)
   if (NOT LibXml2_FOUND)

--- a/cmake/Modules/DefineCompilerFlags.cmake
+++ b/cmake/Modules/DefineCompilerFlags.cmake
@@ -7,6 +7,14 @@ if (${CMAKE_C_COMPILER_ID} MATCHES "Clang")
   set (COMPILER_IS_CLANG TRUE)
 endif (${CMAKE_C_COMPILER_ID} MATCHES "Clang")
 
+if (CGREEN_WITH_XML)
+  add_definitions(-DHAVE_XML_REPORTER=1)
+endif (CGREEN_WITH_XML)
+
+if (CGREEN_WITH_LIBXML2)
+  add_definitions(-DHAVE_LIBXML2_REPORTER=1)
+endif (CGREEN_WITH_LIBXML2)
+
 if (UNIX)
   if (CMAKE_COMPILER_IS_GNUCC OR COMPILER_IS_CLANG)
     # add_compile_options(-Wall -Wextra -Wunused) # only since CMake 2.8.12, so...
@@ -16,7 +24,6 @@ if (UNIX)
       # libxml2 headers depend on ICU library for Unicode support,
       # but ICU headers do not even compile with C++ 98.
       set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
-      add_definitions(-DHAVE_LIBXML2_REPORTER=1)
     else ()
       set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++98")
     endif (CGREEN_WITH_LIBXML2)

--- a/cmake/Modules/DefineCompilerFlags.cmake
+++ b/cmake/Modules/DefineCompilerFlags.cmake
@@ -12,7 +12,15 @@ if (UNIX)
     # add_compile_options(-Wall -Wextra -Wunused) # only since CMake 2.8.12, so...
     add_definitions(-Wall -Wextra -Wunused)
 
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++98 -Weffc++")
+    if (CGREEN_WITH_LIBXML2)
+      # libxml2 headers depend on ICU library for Unicode support,
+      # but ICU headers do not even compile with C++ 98.
+      set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
+      add_definitions(-DHAVE_LIBXML2_REPORTER=1)
+    else ()
+      set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++98")
+    endif (CGREEN_WITH_LIBXML2)
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Weffc++")
     set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -std=c99 -Wstrict-prototypes")
 
     if (CGREEN_INTERNAL_WITH_GCOV)

--- a/include/cgreen/xml_reporter.h
+++ b/include/cgreen/xml_reporter.h
@@ -13,6 +13,7 @@ namespace cgreen {
 #endif
 
 TestReporter *create_xml_reporter(const char *prefix);
+TestReporter *create_libxml_reporter(const char *prefix);
 
 #ifdef __cplusplus
     }

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -111,7 +111,7 @@ cmake_define_relative_file_paths ("${cgreen_SRCS}")
 include_directories(
   ${CGREEN_PUBLIC_INCLUDE_DIRS}
   ${CGREEN_PRIVATE_INCLUDE_DIRS}
-  ${LIBXML2_INCLUDE_DIRS}
+  $<$<BOOL:${CGREEN_WITH_LIBXML2}>:${LIBXML2_INCLUDE_DIRS}>
 )
 
 ### cgreen
@@ -124,7 +124,7 @@ target_link_libraries(
   ${CMAKE_THREAD_LIBS_INIT}
   ${MATH_LIB}
   ${CMAKE_CXX_IMPLICIT_LINK_LIBRARIES}
-  ${LIBXML2_LIBRARIES}
+  $<$<BOOL:${CGREEN_WITH_LIBXML2}>:${LIBXML2_LIBRARIES}>
 )
 
 set_target_properties(

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -69,6 +69,9 @@ set(cgreen_SRCS
   ${CMAKE_CURRENT_SOURCE_DIR}/vector.c
   ${CMAKE_CURRENT_SOURCE_DIR}/xml_reporter.c
 )
+if (CGREEN_WITH_LIBXML2)
+  LIST(APPEND cgreen_SRCS ${CMAKE_CURRENT_SOURCE_DIR}/libxml_reporter.c)
+endif (CGREEN_WITH_LIBXML2)
 
 if (MSYS)
   # Msys2 is difficult since it really is three different "OS":es, Msys native, W32 and W64
@@ -108,6 +111,7 @@ cmake_define_relative_file_paths ("${cgreen_SRCS}")
 include_directories(
   ${CGREEN_PUBLIC_INCLUDE_DIRS}
   ${CGREEN_PRIVATE_INCLUDE_DIRS}
+  ${LIBXML2_INCLUDE_DIRS}
 )
 
 ### cgreen
@@ -120,6 +124,7 @@ target_link_libraries(
   ${CMAKE_THREAD_LIBS_INIT}
   ${MATH_LIB}
   ${CMAKE_CXX_IMPLICIT_LINK_LIBRARIES}
+  ${LIBXML2_LIBRARIES}
 )
 
 set_target_properties(

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -67,8 +67,10 @@ set(cgreen_SRCS
   ${CMAKE_CURRENT_SOURCE_DIR}/text_reporter.c
   ${CMAKE_CURRENT_SOURCE_DIR}/utils.c
   ${CMAKE_CURRENT_SOURCE_DIR}/vector.c
-  ${CMAKE_CURRENT_SOURCE_DIR}/xml_reporter.c
 )
+if (CGREEN_WITH_XML)
+  LIST(APPEND cgreen_SRCS ${CMAKE_CURRENT_SOURCE_DIR}/xml_reporter.c)
+endif (CGREEN_WITH_XML)
 if (CGREEN_WITH_LIBXML2)
   LIST(APPEND cgreen_SRCS ${CMAKE_CURRENT_SOURCE_DIR}/libxml_reporter.c)
 endif (CGREEN_WITH_LIBXML2)

--- a/src/libxml_reporter.c
+++ b/src/libxml_reporter.c
@@ -1,0 +1,490 @@
+#include <cgreen/breadcrumb.h>
+#include <stdio.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+#include <errno.h>
+#include <inttypes.h>
+#include <assert.h>
+
+#include <libxml/xmlwriter.h>
+#include <libxml/encoding.h>
+#include <libxml/xmlIO.h>
+#include <libxml/tree.h>
+
+#include "libxml_reporter_internal.h"
+
+#ifdef __ANDROID__
+#include "cgreen/internal/android_headers/androidcompat.h"
+#endif // #ifdef __ANDROID__
+
+typedef struct {
+    XmlPrinter *printer;
+    int segment_count;
+} XmlMemo;
+
+#define XMLSTRING(x) (BAD_CAST x)
+
+static void xml_reporter_start_suite(TestReporter *reporter, const char *name,
+                                     int count);
+static void xml_reporter_start_test(TestReporter *reporter, const char *name);
+static void xml_reporter_finish_test(TestReporter *reporter, const char *filename,
+                                     int line, const char *message);
+static void xml_reporter_finish_suite(TestReporter *reporter, const char *filename,
+                                      int line);
+static void xml_show_skip(TestReporter *reporter, const char *file, int line);
+static void xml_show_fail(TestReporter *reporter, const char *file, int line,
+                          const char *message, va_list arguments);
+static void xml_show_incomplete(TestReporter *reporter, const char *filename,
+                                int line, const char *message, va_list arguments);
+
+static const char *file_prefix;
+
+static int default_printer(xmlDocPtr doc);
+
+void set_libxml_reporter_printer(TestReporter *reporter, XmlPrinter *printer)
+{
+    XmlMemo *memo = (XmlMemo*)reporter->memo;
+    memo->printer = printer;
+}
+
+TestReporter *create_libxml_reporter(const char *prefix) {
+    TestReporter *reporter;
+    XmlMemo *memo;
+
+    reporter = create_reporter();
+    if (reporter == NULL) {
+        return NULL;
+    }
+
+    memo = (XmlMemo *) malloc(sizeof(XmlMemo));
+    if (memo == NULL) {
+        destroy_reporter(reporter);
+        return NULL;
+    }
+    reporter->memo = memo;
+    memo->printer = &default_printer;
+
+    file_prefix = prefix;
+    reporter->start_suite = &xml_reporter_start_suite;
+    reporter->start_test = &xml_reporter_start_test;
+    reporter->show_fail = &xml_show_fail;
+    reporter->show_skip = &xml_show_skip;
+    reporter->show_incomplete = &xml_show_incomplete;
+    reporter->finish_test = &xml_reporter_finish_test;
+    reporter->finish_suite = &xml_reporter_finish_suite;
+    return reporter;
+}
+
+#ifndef PATH_MAX
+#define PATH_MAX 4096
+#endif
+static char suite_path[PATH_MAX];
+
+static void print_path_separator_if_needed(int *more_segments) {
+    if (*more_segments > 0) {
+        strcat(suite_path, "/");
+        (*more_segments)--;
+    }
+}
+
+static void print_path_segment_walker(const char *segment, void *void_memo) {
+    XmlMemo *memo = (XmlMemo *)void_memo;
+
+    strncat(suite_path, segment, sizeof(suite_path)-strlen(suite_path)-1);
+    print_path_separator_if_needed(&memo->segment_count);
+}
+
+static void strcat_path_segment(const char *segment, void *more_segments) {
+    (void)more_segments;
+    if (suite_path[0] != '\0') strcat(suite_path, "-");
+    strncat(suite_path, segment, sizeof(suite_path)-strlen(suite_path)-1);
+}
+
+static void add_suite_name(const char *suite_name) {
+    if (suite_path[0] != '\0')
+        strcat(suite_path, "-");
+    strncat(suite_path, suite_name, sizeof(suite_path)-strlen(suite_path)-1);
+}
+
+#define NESTED_SUITE_MAX 100
+struct xml_suite_context {
+    xmlDocPtr doc;
+    xmlNodePtr suite, curTest;
+    FILE* outFile;
+    uint32_t suite_duration;
+};
+static struct xml_suite_context context_stack[NESTED_SUITE_MAX];
+static int context_stack_p = 0;
+
+/*
+ * The table below is taken from the "Non-restricted characters" section of
+ * https://en.wikipedia.org/wiki/Valid_characters_in_XML
+ */
+static bool isNonRestrictedXMLChar(unsigned int c) {
+    return (c == 0x09u || c == 0x0Au || c == 0x0Du ||
+            (c >= 0x20u && c <= 0x7Eu) || c == 0x85u ||
+            (c >= 0xA0u && c <= 0xD7FFu) ||
+            (c >= 0xE000u && c <= 0xFDCFu) ||
+            (c >= 0xFDF0u && c <= 0xFFFDu) ||
+            (c >= 0x10000u && c <= 0x1FFFDu) ||
+            (c >= 0x20000u && c <= 0x2FFFDu) ||
+            (c >= 0x30000u && c <= 0x3FFFDu) ||
+            (c >= 0x40000u && c <= 0x4FFFDu) ||
+            (c >= 0x50000u && c <= 0x5FFFDu) ||
+            (c >= 0x60000u && c <= 0x6FFFDu) ||
+            (c >= 0x70000u && c <= 0x7FFFDu) ||
+            (c >= 0x80000u && c <= 0x8FFFDu) ||
+            (c >= 0x90000u && c <= 0x9FFFDu) ||
+            (c >= 0xA0000u && c <= 0xAFFFDu) ||
+            (c >= 0xB0000u && c <= 0xBFFFDu) ||
+            (c >= 0xC0000u && c <= 0xCFFFDu) ||
+            (c >= 0xD0000u && c <= 0xDFFFDu) ||
+            (c >= 0xE0000u && c <= 0xEFFFDu) ||
+            (c >= 0xF0000u && c <= 0xFFFFDu) ||
+            (c >= 0x100000u && c <= 0x10FFFD));
+}
+
+static bool isOverlongUTF8(unsigned int ucs, int len)
+{
+    return ((ucs <= 0x7f && len > 1) ||
+            (ucs <= 0x7ff && len > 2) ||
+            (ucs <= 0xffff && len > 3) ||
+            (ucs <= 0x10ffff && len > 4));
+}
+
+/*
+ * Return a copy of the argument prepared to be used as an attribute value.
+ * The produced result is not necessary convertable back to the original set
+ * of bytes.
+ */
+static xmlChar* xmlEscapePropValue(const char *str) {
+    size_t len = strlen(str);
+    /*
+     * The worst-case length of the output is 4 times the input length (if
+     * every input byte has to be escaped) plus 1 for the terminating NUL
+     * character
+     */
+    size_t retLen = len * 4 + 1;
+    xmlChar* ret = xmlMalloc(retLen), *retPos = ret, *retEnd = ret + retLen;
+    if (!ret) {
+        fprintf(stderr, "memory allocation failure in %s\n", __func__);
+        exit(EXIT_FAILURE);
+    }
+
+    const unsigned char *it = (const unsigned char*)str;
+    const unsigned char *itEnd = it + len;
+    while (*it) {
+        int utfLen = itEnd - it;
+        int ucs = xmlGetUTF8Char(it, &utfLen);
+        if (ucs != -1) {
+            if (!isOverlongUTF8(ucs, utfLen)) {
+                if (isNonRestrictedXMLChar(ucs)) {
+                    /* Valid UTF8 sequence of an allowed character */
+                    while (utfLen--)
+                        *retPos++ = *it++;
+                } else {
+                    xmlStrPrintf(retPos, retEnd - retPos, "&x%x;", ucs);
+                }
+            } else {
+                /* Disallowed character or overlong UTF8, escape entire sequence */
+                for(int i = 0;i < utfLen;++i) {
+                    xmlStrPrintf(retPos, retEnd-retPos, "\\x%.2" PRIx8, *it);
+                    retPos += 4;
+                    ++it;
+                }
+            }
+        } else {
+            /* Invalid UTF8, escape one byte then try to parse rest of input as UTF8 again */
+            xmlStrPrintf(retPos, retEnd-retPos, "\\x%.2" PRIx8, *it);
+            retPos += 4;
+            ++it;
+        }
+    }
+
+    *retPos = '\0';
+    return ret;
+}
+
+static void xml_reporter_start_suite(TestReporter *reporter, const char *suitename, int count) {
+    char filename[PATH_MAX];
+    int segment_decrementer = reporter->breadcrumb->depth;
+    XmlMemo *memo = (XmlMemo *)reporter->memo;
+    if (context_stack_p >= NESTED_SUITE_MAX)
+        abort();
+    struct xml_suite_context *ctx = &context_stack[context_stack_p++];
+
+    FILE *out;
+
+    (void)count;                /* UNUSED */
+
+    reporter->passes = 0;
+    reporter->failures = 0;
+    reporter->skips = 0;
+    reporter->exceptions = 0;
+
+    suite_path[0] = '\0';
+    walk_breadcrumb(reporter->breadcrumb, strcat_path_segment, &segment_decrementer);
+    add_suite_name(suitename);
+
+    if (snprintf(filename, sizeof(filename), "%s-%s.xml", file_prefix, suite_path) >= (int)sizeof(filename)) {
+        fprintf(stderr, "filename truncated; exceeds PATH_MAX (= %d)\n", PATH_MAX);
+        exit(EXIT_FAILURE);
+    }
+    if (memo->printer == default_printer) {
+        // If we're really printing to files, then open one...
+        out = fopen(filename, "w");
+        if (!out) {
+            fprintf(stderr, "could not open %s: %s\r\n", filename, strerror(errno));
+            exit(EXIT_FAILURE);
+        }
+        ctx->outFile = out;
+    }
+
+    ctx->suite_duration = 0;
+    ctx->doc = xmlNewDoc(XMLSTRING("1.0"));
+    ctx->suite = xmlNewNode(NULL, XMLSTRING("testsuite"));
+    xmlChar *xml_suite_path = xmlEscapePropValue(suite_path);
+    xmlNewProp(ctx->suite, XMLSTRING("name"), xml_suite_path);
+    xmlFree(xml_suite_path);
+    xmlDocSetRootElement(ctx->doc, ctx->suite);
+
+    reporter_start_suite(reporter, suitename, 0);
+}
+
+
+/* Accumulate output from the actual test (the "<testcase>" nodes) in
+   a file since the tests usually are run in a child processes, so
+   there is no simple way to save output from it and then use it in
+   the parent (start_test() and finish_test() are run from parent) */
+
+static FILE *child_output_tmpfile;
+static xmlTextWriterPtr child_output_writer;
+
+static void xml_reporter_start_test(TestReporter *reporter, const char *testname) {
+    XmlMemo *memo = (XmlMemo *)reporter->memo;
+    struct xml_suite_context *ctx = &context_stack[context_stack_p-1];
+
+    ctx->curTest = xmlNewChild(ctx->suite, NULL, XMLSTRING("testcase"), NULL);
+    xmlChar *xml_testname = xmlEscapePropValue(testname);
+    xmlNewProp(ctx->curTest, XMLSTRING("name"), xml_testname);
+    xmlFree(xml_testname);
+
+    memo->segment_count = reporter->breadcrumb->depth - 1;
+    suite_path[0] = '\0';
+    walk_breadcrumb(reporter->breadcrumb, print_path_segment_walker, memo);
+    xmlChar* xml_suite_path = xmlEscapePropValue(suite_path);
+    xmlNewProp(ctx->curTest, XMLSTRING("classname"), xml_suite_path);
+    xmlFree(xml_suite_path);
+
+    reporter_start_test(reporter, testname);
+
+    child_output_tmpfile = tmpfile();
+    xmlOutputBufferPtr tmpfileBuf
+        = xmlOutputBufferCreateFile(child_output_tmpfile,
+                                    xmlGetCharEncodingHandler(XML_CHAR_ENCODING_UTF8));
+    child_output_writer = xmlNewTextWriter(tmpfileBuf);
+}
+
+
+static void xml_show_skip(TestReporter *reporter, const char *file, int line) {
+    (void)file;
+    (void)line;
+    (void)reporter;
+
+    xmlTextWriterStartElement(child_output_writer, XMLSTRING("skipped"));
+    xmlTextWriterEndElement(child_output_writer); // </skipped>
+    xmlTextWriterFlush(child_output_writer);
+}
+
+static xmlChar* xml_secure_vprint(const char *format, va_list ap)
+{
+    char buf[100];
+    char *msg = buf;
+    const size_t len = sizeof(buf);
+
+    va_list ap_store;
+    va_copy(ap_store, ap);
+    int res = vsnprintf(msg, len, format, ap_store);
+    va_end(ap_store);
+    if (res < 0) {
+        fprintf(stderr, "vsnprintf failed in xml_secure_vprint: %s\n", strerror(res));
+        exit(EXIT_FAILURE);
+    }
+
+    if ((unsigned)res >= len) {
+        size_t msglen = res+1;
+        msg = malloc(msglen);
+        if (!msg) {
+            fprintf(stderr, "memory allocation failure in xml_secure_vprint\n");
+            exit(EXIT_FAILURE);
+        }
+        res = vsnprintf(msg, msglen, format, ap);
+        if (res < 0) {
+            free(msg);
+            fprintf(stderr, "vsnprintf failed in xml_secure_vprint: %s\n", strerror(res));
+            exit(EXIT_FAILURE);
+        }
+        if ((unsigned)res >= msglen) {
+            // What? Did format get longer while allocating msg?
+            free(msg);
+            fprintf(stderr, "vsnprintf failed in xml_secure_vprint: nondeterministic message length\n");
+            exit(EXIT_FAILURE);
+        }
+    }
+
+    xmlChar *xml_msg = xmlEscapePropValue(msg);
+    if (msg != buf) free(msg);
+    return xml_msg;
+}
+
+static void xml_show_fail(TestReporter *reporter, const char *file, int line,
+                          const char *message, va_list arguments) {
+    (void)reporter;
+
+    xmlTextWriterStartElement(child_output_writer, XMLSTRING("failure"));
+
+    xmlChar *xml_str = xml_secure_vprint(message, arguments);
+    xmlTextWriterWriteAttribute(child_output_writer, XMLSTRING("message"), xml_str);
+    xmlFree(xml_str);
+
+    xmlTextWriterStartElement(child_output_writer, XMLSTRING("location"));
+    xmlChar *xml_file = xmlEscapePropValue(file);
+    xmlTextWriterWriteAttribute(child_output_writer, XMLSTRING("file"), xml_file);
+    xmlFree(xml_file);
+    xmlTextWriterWriteFormatAttribute(child_output_writer, XMLSTRING("line"), "%d", line);
+    xmlTextWriterEndElement(child_output_writer); // </location>
+    xmlTextWriterEndElement(child_output_writer); // </failure>
+    xmlTextWriterFlush(child_output_writer);
+}
+
+static xmlAttrPtr xmlFormatProp(xmlNodePtr node, const xmlChar* name, const char *format, ...)
+{
+    va_list vargs;
+    va_start(vargs, format);
+    xmlChar *xml_str = xml_secure_vprint(format, vargs);
+    va_end(vargs);
+
+    xmlAttrPtr attr = xmlNewProp(node, name, xml_str);
+    xmlFree(xml_str);
+
+    return attr;
+}
+
+static void xml_show_incomplete(TestReporter *reporter, const char *filename,
+                                int line, const char *message, va_list arguments) {
+    (void)reporter;
+
+    struct xml_suite_context *ctx = &context_stack[context_stack_p-1];
+
+    xmlNodePtr errNode = xmlNewChild(ctx->curTest, NULL, XMLSTRING("error"), NULL);
+    xmlNewProp(errNode, XMLSTRING("type"), XMLSTRING("Fatal"));
+    if (message) {
+        xmlChar *xml_msg = xml_secure_vprint(message, arguments);
+        xmlNewProp(errNode, XMLSTRING("message"), xml_msg);
+        xmlFree(xml_msg);
+    } else {
+        xmlNewProp(errNode, XMLSTRING("message"),
+                   XMLSTRING("Test terminated unexpectedly, likely from a non-standard exception or Posix signal"));
+    }
+    xmlNodePtr locNode = xmlNewChild(errNode, NULL, XMLSTRING("location"), NULL);
+    xmlChar *xml_filename = xmlEscapePropValue(filename);
+    xmlNewProp(locNode, XMLSTRING("file"), xml_filename);
+    xmlFree(xml_filename);
+    xmlFormatProp(locNode, XMLSTRING("line"), "%d", line);
+}
+
+static void insert_child_results(struct xml_suite_context *ctx) {
+    char childData[4096];
+    fseek(child_output_tmpfile, 0, SEEK_SET);
+
+    size_t pos = 0, ret;
+    while (!feof(child_output_tmpfile)) {
+        ret = fread(childData+pos, 1, sizeof(childData)-pos, child_output_tmpfile);
+        if (ferror(child_output_tmpfile)) {
+            abort();
+        }
+        pos += ret;
+    }
+
+    fclose(child_output_tmpfile);
+    if (pos > 0) {
+        childData[pos] = '\0';
+
+        xmlNodePtr childLst;
+        if (xmlParseBalancedChunkMemoryRecover(ctx->doc, NULL, NULL, 0, XMLSTRING(childData), &childLst, 1) != 0) {
+            xmlNodePtr errNode = xmlNewChild(ctx->curTest, NULL, XMLSTRING("error"), NULL);
+            xmlNewProp(errNode, XMLSTRING("type"), XMLSTRING("Fatal"));
+            xmlNewProp(errNode, XMLSTRING("message"),
+                       XMLSTRING("Test result XML truncated or malformed, "
+                                 "likely from abnormal process termination"));
+        }
+
+        xmlAddChildList(ctx->curTest, childLst);
+    }
+}
+
+static void xml_reporter_finish_test(TestReporter *reporter, const char *filename,
+                                     int line, const char *message) {
+    struct xml_suite_context *ctx = &context_stack[context_stack_p-1];
+
+    reporter_finish_test(reporter, filename, line, message);
+    xmlFreeTextWriter(child_output_writer);
+
+    xmlFormatProp(ctx->curTest, XMLSTRING("time"),
+                  "%.5f", (double)reporter->duration/(double)1000);
+
+    ctx->suite_duration += reporter->duration;
+    insert_child_results(ctx);
+}
+
+static void deleteEmpty(xmlNodePtr elem)
+{
+    while (elem != NULL) {
+        xmlNodePtr next = elem->next;
+        if (xmlIsBlankNode(elem)) {
+            xmlUnlinkNode(elem);
+            xmlFreeNode(elem);
+        } else if (elem->children) {
+            deleteEmpty(elem->children);
+        }
+
+        elem = next;
+    }
+}
+
+static int default_printer(xmlDocPtr doc)
+{
+    struct xml_suite_context *ctx = &context_stack[context_stack_p-1];
+    xmlOutputBufferPtr outBuf
+        = xmlOutputBufferCreateFile(ctx->outFile,
+                                    xmlGetCharEncodingHandler(XML_CHAR_ENCODING_UTF8));
+    xmlSaveFormatFileTo(outBuf, doc, "UTF-8", 1);
+
+    return 0;
+}
+
+static void xml_reporter_finish_suite(TestReporter *reporter, const char *filename, int line) {
+    XmlMemo *memo = (XmlMemo *)reporter->memo;
+    struct xml_suite_context *ctx = &context_stack[context_stack_p-1];
+
+    reporter_finish_suite(reporter, filename, line);
+
+    reporter->total_passes += reporter->passes;
+    reporter->total_failures += reporter->failures;
+    reporter->total_skips += reporter->skips;
+    reporter->total_exceptions += reporter->exceptions;
+
+    xmlFormatProp(ctx->suite, XMLSTRING("failures"), "%d", reporter->failures);
+    xmlFormatProp(ctx->suite, XMLSTRING("errors"), "%d", reporter->exceptions);
+    xmlFormatProp(ctx->suite, XMLSTRING("skipped"), "%d", reporter->skips);
+    xmlFormatProp(ctx->suite, XMLSTRING("time"), "%.5f", (double)ctx->suite_duration/(double)1000);
+
+    deleteEmpty(ctx->suite);
+    memo->printer(ctx->doc);
+    xmlFreeDoc(ctx->doc);
+    if (context_stack_p > 1) {
+        context_stack[context_stack_p-2].suite_duration += ctx->suite_duration;
+    }
+    --context_stack_p;
+}

--- a/src/libxml_reporter_internal.h
+++ b/src/libxml_reporter_internal.h
@@ -9,7 +9,6 @@
 extern "C" {
 #endif
 
-#include <stdio.h>
 typedef int XmlPrinter(xmlDocPtr);
 extern void set_libxml_reporter_printer(TestReporter *reporter, XmlPrinter *printer);
 

--- a/src/libxml_reporter_internal.h
+++ b/src/libxml_reporter_internal.h
@@ -1,0 +1,20 @@
+#ifndef XML_REPORTER_INTERNAL_H
+#define XML_REPORTER_INTERNAL_H
+
+#include <libxml/tree.h>
+
+#include <cgreen/xml_reporter.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include <stdio.h>
+typedef int XmlPrinter(xmlDocPtr);
+extern void set_libxml_reporter_printer(TestReporter *reporter, XmlPrinter *printer);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -53,6 +53,9 @@ set(c_tests_library_SRCS
   vector_tests.c
   xml_reporter_tests.c
 )
+if (CGREEN_WITH_LIBXML2)
+  LIST(APPEND c_tests_library_SRCS libxml_reporter_tests.c)
+endif (CGREEN_WITH_LIBXML2)
 SET_SOURCE_FILES_PROPERTIES(${c_tests_library_SRCS} PROPERTIES LANGUAGE C)
 
 set(CGREEN_C_TESTS_LIBRARY
@@ -61,7 +64,13 @@ set(CGREEN_C_TESTS_LIBRARY
 )
 
 add_library(${CGREEN_C_TESTS_LIBRARY} SHARED ${c_tests_library_SRCS})
-target_link_libraries(${CGREEN_C_TESTS_LIBRARY} ${CGREEN_LIBRARY})
+if (CGREEN_WITH_LIBXML2)
+  target_link_libraries(${CGREEN_C_TESTS_LIBRARY} ${CGREEN_LIBRARY}
+      ${LIBXML2_LIBRARIES})
+  include_directories(${LIBXML2_INCLUDE_DIRS})
+else ()
+  target_link_libraries(${CGREEN_C_TESTS_LIBRARY} ${CGREEN_LIBRARY})
+endif (CGREEN_WITH_LIBXML2)
 macro_add_valgrind_test(${CGREEN_C_TESTS_LIBRARY})
 
 
@@ -148,6 +157,10 @@ foreach(case
   add_library(${${case}_tests_library} SHARED ${${case}_tests_SRCS})
   target_link_libraries(${${case}_tests_library} ${CGREEN_LIBRARY})
 endforeach(case)
+if (CGREEN_WITH_LIBXML2)
+  add_library(${libxml_reporter_tests_library} SHARED libxml_reporter_tests.c)
+  target_link_libraries(${libxml_reporter_tests_library} ${CGREEN_LIBRARY})
+endif (CGREEN_WITH_LIBXML2)
 
 
 # Libraries for a set of output comparing tests to run with runner
@@ -186,6 +199,13 @@ set(xml_output_library xml_output_tests)
 set(xml_output_library_SRCS xml_output_tests.c)
 add_library(${xml_output_library} SHARED ${xml_output_library_SRCS})
 target_link_libraries(${xml_output_library} ${CGREEN_LIBRARY})
+
+if (CGREEN_WITH_LIBXML2)
+  set(libxml_output_library libxml_output_tests)
+  set(libxml_output_library_SRCS libxml_output_tests.c)
+  add_library(${libxml_output_library} SHARED ${libxml_output_library_SRCS})
+  target_link_libraries(${libxml_output_library} ${CGREEN_LIBRARY})
+endif (CGREEN_WITH_LIBXML2)
 
 set(TEST_TARGET_LIBRARIES ${CGREEN_LIBRARY})
 
@@ -241,6 +261,15 @@ macro_add_test(NAME xml_output
             ${CMAKE_CURRENT_SOURCE_DIR}     # Where sources are
             ${xml_output_library}.expected
 )
+
+if (CGREEN_WITH_LIBXML2)
+  macro_add_test(NAME libxml_output
+      COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/../tools/cgreen_libxml_output_diff
+      	libxml_output_tests
+      	${CMAKE_CURRENT_SOURCE_DIR}
+      	${libxml_output_library}.expected
+  )
+endif (CGREEN_WITH_LIBXML2)
 
 # add verification that all public api is available as it should
 add_subdirectory(api)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -76,7 +76,8 @@ set(c_tests_SRCS
 )
 SET_SOURCE_FILES_PROPERTIES(${c_tests_SRCS} PROPERTIES LANGUAGE C)
 
-set(TEST_TARGET_LIBRARIES ${CGREEN_LIBRARY})
+set(TEST_TARGET_LIBRARIES ${CGREEN_LIBRARY}
+    $<$<BOOL:${CGREEN_WITH_LIBXML2}>:${LIBXML2_LIBRARIES}>)
 
 # unit test with main program runner
 macro_add_unit_test(test_cgreen_c "${c_tests_SRCS}" "${TEST_TARGET_LIBRARIES}")

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -154,8 +154,8 @@ foreach(case
   target_link_libraries(${${case}_tests_library} ${CGREEN_LIBRARY})
 endforeach(case)
 if (CGREEN_WITH_LIBXML2)
-  add_library(${libxml_reporter_tests_library} SHARED libxml_reporter_tests.c)
-  target_link_libraries(${libxml_reporter_tests_library} ${CGREEN_LIBRARY})
+  add_library(libxml_reporter_tests SHARED libxml_reporter_tests.c)
+  target_link_libraries(libxml_reporter_tests ${CGREEN_LIBRARY})
 endif (CGREEN_WITH_LIBXML2)
 
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -64,13 +64,9 @@ set(CGREEN_C_TESTS_LIBRARY
 )
 
 add_library(${CGREEN_C_TESTS_LIBRARY} SHARED ${c_tests_library_SRCS})
-if (CGREEN_WITH_LIBXML2)
-  target_link_libraries(${CGREEN_C_TESTS_LIBRARY} ${CGREEN_LIBRARY}
-      ${LIBXML2_LIBRARIES})
-  include_directories(${LIBXML2_INCLUDE_DIRS})
-else ()
-  target_link_libraries(${CGREEN_C_TESTS_LIBRARY} ${CGREEN_LIBRARY})
-endif (CGREEN_WITH_LIBXML2)
+target_link_libraries(${CGREEN_C_TESTS_LIBRARY} ${CGREEN_LIBRARY}
+  $<$<BOOL:${CGREEN_WITH_LIBXML2}>:${LIBXML2_LIBRARIES}>)
+include_directories($<$<BOOL:${CGREEN_WITH_LIBXML2}>:${LIBXML2_INCLUDE_DIRS}>)
 macro_add_valgrind_test(${CGREEN_C_TESTS_LIBRARY})
 
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -51,8 +51,10 @@ set(c_tests_library_SRCS
   text_reporter_tests.c
   unit_tests.c
   vector_tests.c
-  xml_reporter_tests.c
 )
+if (CGREEN_WITH_XML)
+  LIST(APPEND c_tests_library_SRCS xml_reporter_tests.c)
+endif (CGREEN_WITH_XML)
 if (CGREEN_WITH_LIBXML2)
   LIST(APPEND c_tests_library_SRCS libxml_reporter_tests.c)
 endif (CGREEN_WITH_LIBXML2)
@@ -83,8 +85,13 @@ set(TEST_TARGET_LIBRARIES ${CGREEN_LIBRARY}
 macro_add_unit_test(test_cgreen_c "${c_tests_SRCS}" "${TEST_TARGET_LIBRARIES}")
 macro_add_test(NAME test_cgreen_c_run_named_test COMMAND test_cgreen_c integer_one_should_assert_true)
 
+set(cgreen_runner_args)
+if (CGREEN_WITH_XML)
+  set(cgreen_runner_args -x TEST)
+endif (CGREEN_WITH_XML)
+
 # run them with cgreen-runner also
-macro_add_test(NAME runner_test_cgreen_c COMMAND cgreen-runner -x TEST ./${CMAKE_SHARED_LIBRARY_PREFIX}${CGREEN_C_TESTS_LIBRARY}${CMAKE_SHARED_LIBRARY_SUFFIX})
+macro_add_test(NAME runner_test_cgreen_c COMMAND cgreen-runner ${cgreen_runner_args} ./${CMAKE_SHARED_LIBRARY_PREFIX}${CGREEN_C_TESTS_LIBRARY}${CMAKE_SHARED_LIBRARY_SUFFIX})
 
 
 # C++ tests, library to use with runner, and a main program
@@ -119,7 +126,7 @@ SET_SOURCE_FILES_PROPERTIES(${cpp_tests_SRCS} PROPERTIES LANGUAGE CXX)
 
 macro_add_unit_test(test_cgreen_cpp "${cpp_tests_SRCS}" "${TEST_TARGET_LIBRARIES}" ${CMAKE_CXX_IMPLICIT_LINK_LIBRARIES})
 macro_add_test(NAME test_cgreen_cpp_run_named_test COMMAND test_cgreen_cpp different_pointers_with_same_contents_should_assert_equal)
-macro_add_test(NAME runner_test_cgreen_cpp COMMAND cgreen-runner -x TEST ./${CMAKE_SHARED_LIBRARY_PREFIX}${CGREEN_CPP_TESTS_LIBRARY}${CMAKE_SHARED_LIBRARY_SUFFIX})
+macro_add_test(NAME runner_test_cgreen_cpp COMMAND cgreen-runner ${cgreen_runner_args} ./${CMAKE_SHARED_LIBRARY_PREFIX}${CGREEN_CPP_TESTS_LIBRARY}${CMAKE_SHARED_LIBRARY_SUFFIX})
 
 # Temporary single CUT test library
 # Maybe we should do this for all tests instead
@@ -143,7 +150,6 @@ foreach(case
     text_reporter
     unit
     vector
-    xml_reporter
   )
   set(${case}_tests_SRCS
       ${case}_tests.c
@@ -154,6 +160,10 @@ foreach(case
   add_library(${${case}_tests_library} SHARED ${${case}_tests_SRCS})
   target_link_libraries(${${case}_tests_library} ${CGREEN_LIBRARY})
 endforeach(case)
+if (CGREEN_WITH_XML)
+  add_library(xml_reporter_tests SHARED xml_reporter_tests.c)
+  target_link_libraries(xml_reporter_tests ${CGREEN_LIBRARY})
+endif (CGREEN_WITH_XML)
 if (CGREEN_WITH_LIBXML2)
   add_library(libxml_reporter_tests SHARED libxml_reporter_tests.c)
   target_link_libraries(libxml_reporter_tests ${CGREEN_LIBRARY})
@@ -192,10 +202,12 @@ set(ignore_messages_library_SRCS ignore_messages_tests.c)
 add_library(${ignore_messages_library} SHARED ${ignore_messages_library_SRCS})
 target_link_libraries(${ignore_messages_library} ${CGREEN_LIBRARY})
 
-set(xml_output_library xml_output_tests)
-set(xml_output_library_SRCS xml_output_tests.c)
-add_library(${xml_output_library} SHARED ${xml_output_library_SRCS})
-target_link_libraries(${xml_output_library} ${CGREEN_LIBRARY})
+if (CGREEN_WITH_XML)
+  set(xml_output_library xml_output_tests)
+  set(xml_output_library_SRCS xml_output_tests.c)
+  add_library(${xml_output_library} SHARED ${xml_output_library_SRCS})
+  target_link_libraries(${xml_output_library} ${CGREEN_LIBRARY})
+endif (CGREEN_WITH_XML)
 
 if (CGREEN_WITH_LIBXML2)
   set(libxml_output_library libxml_output_tests)
@@ -250,12 +262,14 @@ macro_add_test(NAME ignore_messages
             ${ignore_messages_library}.expected
 )
 
-macro_add_test(NAME xml_output
-    COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/../tools/cgreen_xml_output_diff
-            xml_output_tests                # Name
-            ${CMAKE_CURRENT_SOURCE_DIR}     # Where sources are
-            ${xml_output_library}.expected
-)
+if (CGREEN_WITH_XML)
+  macro_add_test(NAME xml_output
+      COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/../tools/cgreen_xml_output_diff
+              xml_output_tests                # Name
+              ${CMAKE_CURRENT_SOURCE_DIR}     # Where sources are
+              ${xml_output_library}.expected
+  )
+endif (CGREEN_WITH_XML)
 
 if (CGREEN_WITH_LIBXML2)
   macro_add_test(NAME libxml_output

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -204,8 +204,6 @@ if (CGREEN_WITH_LIBXML2)
   target_link_libraries(${libxml_output_library} ${CGREEN_LIBRARY})
 endif (CGREEN_WITH_LIBXML2)
 
-set(TEST_TARGET_LIBRARIES ${CGREEN_LIBRARY})
-
 # TODO We should not add these if the cgreen-runner was not built e.g. no 'nm' available
 macro_add_test(
     NAME constraint_messsages

--- a/tests/all_c_tests.c
+++ b/tests/all_c_tests.c
@@ -27,6 +27,7 @@ TestSuite *text_reporter_tests(void);
 TestSuite *unit_tests(void);
 TestSuite *vector_tests(void);
 TestSuite *xml_reporter_tests(void);
+TestSuite *libxml_reporter_tests(void);
 
 int main(int argc, char **argv) {
     int suite_result;
@@ -52,6 +53,9 @@ int main(int argc, char **argv) {
     add_suite(suite, unit_tests());
     add_suite(suite, vector_tests());
     add_suite(suite, xml_reporter_tests());
+#if HAVE_LIBXML2_REPORTER
+    add_suite(suite, libxml_reporter_tests());
+#endif
 
     if (argc > 1) {
         suite_result = run_single_test(suite, argv[1], reporter);

--- a/tests/all_c_tests.c
+++ b/tests/all_c_tests.c
@@ -52,7 +52,9 @@ int main(int argc, char **argv) {
     add_suite(suite, text_reporter_tests());
     add_suite(suite, unit_tests());
     add_suite(suite, vector_tests());
+#if HAVE_XML_REPORTER
     add_suite(suite, xml_reporter_tests());
+#endif
 #if HAVE_LIBXML2_REPORTER
     add_suite(suite, libxml_reporter_tests());
 #endif

--- a/tests/libxml_output_tests.c
+++ b/tests/libxml_output_tests.c
@@ -1,0 +1,9 @@
+#include <cgreen/cgreen.h>
+
+Ensure(failing_test_is_listed_by_libxml_reporter) {
+    assert_that(false);
+}
+
+Ensure(passing_test_is_listed_by_libxml_reporter) {
+    assert_that(true);
+}

--- a/tests/libxml_output_tests.expected
+++ b/tests/libxml_output_tests.expected
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuite name="xml_output_tests" failures="0" errors="0" skipped="0" time="0.00000"/>
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuite name="libxml_output_tests-default" failures="1" errors="0" skipped="0" time="0.00000">
+  <testcase name="failing_test_is_listed_by_libxml_reporter" classname="libxml_output_tests/default" time="0.00000">
+    <failure message="Expected [0] to [be true]">
+      <location file="xml_output_tests.c" line="0"/>
+    </failure>
+  </testcase>
+  <testcase name="passing_test_is_listed_by_libxml_reporter" classname="libxml_output_tests/default" time="0.00000"/>
+</testsuite>

--- a/tests/libxml_reporter_tests.c
+++ b/tests/libxml_reporter_tests.c
@@ -1,0 +1,395 @@
+#include <cgreen/cgreen.h>
+#include <cgreen/breadcrumb.h>
+#include <cgreen/messaging.h>
+#include "cgreen_value_internal.h"
+#include "constraint_internal.h"
+
+#include <stdio.h>
+#include <string.h>
+#include <unistd.h>
+#include <stdint.h>
+
+#include <libxml/tree.h>
+
+#ifdef __cplusplus
+using namespace cgreen;
+#endif
+
+
+#include "libxml_reporter_internal.h"
+
+#define XMLSTRING(x) (BAD_CAST x)
+
+static const int line=666;
+static xmlChar *output = NULL;
+
+static void clear_output(void)
+{
+    if (NULL != output) {
+        xmlFree(output);
+    }
+    output = NULL;
+}
+
+static int mocked_xmlout(xmlDocPtr doc) {
+    if (output) {
+        xmlFree(output);
+    }
+
+    xmlDocDumpMemoryEnc(doc, &output, NULL, "UTF-8");
+    return 0;
+}
+
+static TestReporter *reporter;
+
+static void setup_xml_reporter_tests(void) {
+    reporter = create_libxml_reporter("PREFIX");
+
+    // We can not use setup_reporting() since we are running
+    // inside a test suite which needs the real reporting
+    // So we'll have to set up the messaging explicitly
+    reporter->ipc = start_cgreen_messaging(667);
+
+    clear_output();
+    set_libxml_reporter_printer(reporter, mocked_xmlout);
+}
+
+static void teardown_xml_reporter_tests(void) {
+    //bad mojo when running tests in same process, as destroy_reporter also sets
+    //context.reporter = NULL, thus breaking the next test to run
+    destroy_reporter(reporter);
+    if (NULL != output) {
+        free(output);
+        //need to set output to NULL to avoid second free in
+        //subsequent call to setup_xml_reporter_tests->clear_output
+        //when running tests in same process
+        output = NULL;
+    }
+}
+
+static xmlChar* getAttribute(xmlNodePtr node, const xmlChar* name) {
+    xmlAttr *attr = node->properties;
+    while (attr) {
+        if (xmlStrEqual(attr->name, name)) {
+            return xmlNodeGetContent((xmlNode*)attr);
+        }
+        attr = attr->next;
+    }
+
+    return NULL;
+}
+
+static bool hasAttribute(xmlNodePtr node, const xmlChar* name) {
+    xmlAttr *attr = node->properties;
+    while (attr) {
+        if (xmlStrEqual(attr->name, name)) {
+            return true;
+        }
+        attr = attr->next;
+    }
+
+    return false;
+}
+
+struct xmlNode_has_attribute_equal_to {
+    xmlChar *attr, *value;
+};
+
+static bool compare_xmlNode_has_attribute_equal_to(Constraint *constraint,
+                                                   CgreenValue actual) {
+    xmlNodePtr actualNode =  (xmlNodePtr)actual.value.pointer_value;
+    struct xmlNode_has_attribute_equal_to *expected =
+        (struct xmlNode_has_attribute_equal_to*)constraint->expected_value.value.pointer_value;
+    xmlChar* actualValue = getAttribute(actualNode, expected->attr);
+
+    bool ret = xmlStrEqual(actualValue, expected->value);
+    xmlFree(actualValue);
+    return ret;
+}
+
+static char *failure_message_xmlNode_has_attribute_equal_to(
+    Constraint *constraint, const char *actual_string, intptr_t actual_value) {
+    struct xmlNode_has_attribute_equal_to *expected =
+        (struct xmlNode_has_attribute_equal_to*)constraint->expected_value.value.pointer_value;
+    xmlChar* actualValue = getAttribute((xmlNodePtr)actual_value, expected->attr);
+
+    const char *message_template = "Expected attribute [%s] of [%s] to [equal] [%s]\n"
+        "\tactual value:\t\t[%s]\n"
+        "\texpected to equal:\t[%s]\n";
+    size_t msglen = xmlStrlen(expected->attr) + strlen(actual_string) +
+        strlen(constraint->expected_value_name) + xmlStrlen(actualValue) +
+        xmlStrlen(expected->value) + strlen(message_template);
+    char *message = (char*)malloc(msglen);
+    if (!message) {
+        xmlFree(actualValue);
+        return NULL;
+    }
+
+    if (snprintf(message, msglen, message_template,
+                 expected->attr, actual_string, constraint->expected_value_name,
+                 actualValue, expected->value) >= (ssize_t)msglen) {
+        xmlFree(actualValue);
+        free(message);
+        return NULL;
+    }
+
+    xmlFree(actualValue);
+    return message;
+}
+
+static void destroy_xmlNode_has_attribute_equal_to(Constraint* constraint) {
+    struct xmlNode_has_attribute_equal_to *expected =
+        (struct xmlNode_has_attribute_equal_to*)constraint->expected_value.value.pointer_value;
+    xmlFree(expected->attr);
+    xmlFree(expected->value);
+    free(expected);
+    destroy_empty_constraint(constraint);
+}
+
+static Constraint *create_xmlNode_has_attribute_equal_to(const xmlChar* attr,
+                                                         const xmlChar *value,
+                                                         const char* expected_value_name)
+{
+    Constraint *constraint = create_constraint();
+    if (!constraint)
+        return NULL;
+
+    struct xmlNode_has_attribute_equal_to *expected =
+        (struct xmlNode_has_attribute_equal_to *)malloc(sizeof(struct xmlNode_has_attribute_equal_to));
+    if (!expected) {
+        constraint->destroy(constraint);
+        return NULL;
+    }
+
+    expected->attr = xmlStrdup(attr);
+    expected->value = xmlStrdup(value);
+
+    constraint->expected_value = make_cgreen_pointer_value(expected);
+    constraint->expected_value_name = strdup(expected_value_name);
+    constraint->type = CGREEN_STRING_COMPARER_CONSTRAINT;
+
+    constraint->compare = &compare_xmlNode_has_attribute_equal_to;
+    constraint->failure_message = &failure_message_xmlNode_has_attribute_equal_to;
+    constraint->name = "have attribute with value";
+    constraint->size_of_expected_value = sizeof(intptr_t);
+    constraint->destroy = &destroy_xmlNode_has_attribute_equal_to;
+
+    return constraint;
+}
+
+#define xmlnode_has_attribute_equal_to(attr, value) \
+    create_xmlNode_has_attribute_equal_to(XMLSTRING(attr), XMLSTRING(value), #value)
+
+static xmlNodePtr xmlnode_find_sibling(xmlNodePtr node, const char *name)
+{
+    while (node) {
+        if (xmlStrEqual(node->name, XMLSTRING(name)))
+            break;
+        node = xmlNextElementSibling(node);
+    }
+    return node;
+}
+
+Describe(LibXmlReporter);
+BeforeEach(LibXmlReporter) {
+    setup_xml_reporter_tests();
+}
+AfterEach(LibXmlReporter) {
+    teardown_xml_reporter_tests();
+}
+
+
+Ensure(LibXmlReporter, will_report_beginning_of_suite) {
+    reporter->start_suite(reporter, "suite_name", 2);
+    reporter->finish_suite(reporter, "filename", line);
+
+    xmlDocPtr doc = xmlParseDoc(output);
+    assert_that(doc, is_not_null);
+
+    xmlNodePtr testsuite = xmlDocGetRootElement(doc);
+    assert_that(testsuite->name, is_equal_to_string("testsuite"));
+    assert_that(xmlChildElementCount(testsuite), is_equal_to(0));
+    assert_that(testsuite, xmlnode_has_attribute_equal_to("name", "suite_name"));
+    xmlFreeDoc(doc);
+}
+
+
+static void reporter_show_pass_vargs(TestReporter *reporter, const char *name, int line,
+                                     const char *format, ...)
+{
+    va_list vargs;
+    va_start(vargs, format);
+    reporter->show_pass(reporter, name, line, format, vargs);
+    va_end(vargs);
+}
+
+Ensure(LibXmlReporter, will_report_beginning_and_successful_finishing_of_passing_test) {
+    reporter->start_suite(reporter, "suite_name", 2);
+    reporter->start_test(reporter, "test_name");
+    reporter_show_pass_vargs(reporter, "file", 2, "test_name");
+    send_reporter_completion_notification(reporter);
+    reporter->finish_test(reporter, "filename", line, NULL);
+    reporter->finish_suite(reporter, "filename", line);
+
+    xmlDocPtr doc = xmlParseDoc(output);
+    assert_that(doc, is_not_null);
+
+    xmlNodePtr testsuite = xmlDocGetRootElement(doc);
+    assert_that(xmlChildElementCount(testsuite), is_equal_to(1));
+
+    xmlNodePtr testcase = xmlFirstElementChild(testsuite);
+    assert_that(testcase->name, is_equal_to_string("testcase"));
+    assert_that(xmlChildElementCount(testcase), is_equal_to(0));
+    assert_that(testcase, xmlnode_has_attribute_equal_to("name", "test_name"));
+    assert_that(testcase, xmlnode_has_attribute_equal_to("classname", "suite_name"));
+}
+
+
+static void reporter_show_fail_vargs(TestReporter *reporter, const char *name, int line,
+                                     const char *format, ...)
+{
+    va_list vargs;
+    va_start(vargs, format);
+    reporter->show_fail(reporter, name, line, format, vargs);
+    va_end(vargs);
+}
+
+Ensure(LibXmlReporter, will_report_a_failing_test) {
+    reporter->start_suite(reporter, "suite_name", 2);
+    reporter->start_test(reporter, "test_name");
+    reporter_show_fail_vargs(reporter, "file", 2, "test_name");
+    send_reporter_completion_notification(reporter);
+    reporter->finish_test(reporter, "filename", line, NULL);
+    reporter->finish_suite(reporter, "filename", line);
+
+    xmlDocPtr doc = xmlParseDoc(output);
+    assert_that(doc, is_not_null);
+
+    xmlNodePtr testsuite = xmlDocGetRootElement(doc);
+    assert_that(xmlChildElementCount(testsuite), is_equal_to(1));
+
+    xmlNodePtr testcase = xmlFirstElementChild(testsuite);
+    assert_that(testcase->name, is_equal_to_string("testcase"));
+    assert_that(xmlChildElementCount(testcase), is_equal_to(1));
+    assert_that(hasAttribute(testcase, XMLSTRING("time")), is_true);
+
+    xmlNodePtr failure = xmlFirstElementChild(testcase);
+    assert_that(failure->name, is_equal_to_string("failure"));
+    assert_that(xmlChildElementCount(failure), is_equal_to(1));
+    assert_that(failure, xmlnode_has_attribute_equal_to("message", "test_name"));
+
+    xmlNodePtr location = xmlFirstElementChild(failure);
+    assert_that(location->name, is_equal_to_string("location"));
+    assert_that(xmlChildElementCount(location), is_equal_to(0));
+    assert_that(location, xmlnode_has_attribute_equal_to("file", "file"));
+    assert_that(location, xmlnode_has_attribute_equal_to("line", "2"));
+}
+
+Ensure(LibXmlReporter, will_report_a_failing_test_only_once) {
+    va_list null_arguments;
+    memset(&null_arguments, 0, sizeof(null_arguments));
+
+    reporter->start_suite(reporter, "suite_name", 2);
+    reporter->start_test(reporter, "test_name");
+    reporter->show_fail(reporter, "file", 2, "test_failure_message", null_arguments);
+    reporter->show_fail(reporter, "file", 2, "other_message", null_arguments);
+    reporter->finish_test(reporter, "filename", line, NULL);
+    reporter->finish_suite(reporter, "filename", line);
+
+    xmlDocPtr doc = xmlParseDoc(output);
+    xmlNodePtr testsuite = xmlDocGetRootElement(doc);
+    xmlNodePtr testcase = xmlFirstElementChild(testsuite);
+
+    static const char FAILURE[] = "failure";
+    xmlNodePtr failure = xmlnode_find_sibling(xmlFirstElementChild(testcase), FAILURE);
+
+    assert_that(failure->name, is_equal_to_string(FAILURE));
+    assert_that(failure, xmlnode_has_attribute_equal_to("message", "test_failure_message"));
+
+    failure = xmlnode_find_sibling(xmlNextElementSibling(failure), FAILURE);
+    assert_that(failure, xmlnode_has_attribute_equal_to("message", "other_message"));
+
+    failure = xmlnode_find_sibling(xmlNextElementSibling(failure), FAILURE);
+    assert_that(failure, is_null);
+}
+
+Ensure(LibXmlReporter, will_mark_ignored_test_as_skipped) {
+    const int line = 666;
+
+    reporter->start_suite(reporter, "suite_name", 1);
+    reporter->start_test(reporter, "skipped_test_name");
+    send_reporter_skipped_notification(reporter);
+    reporter->finish_test(reporter, "filename", line, "message");
+    reporter->finish_suite(reporter, "filename", line);
+
+    xmlDocPtr doc = xmlParseDoc(output);
+    assert_that(doc, is_not_null);
+
+    xmlNodePtr testsuite = xmlDocGetRootElement(doc);
+    assert_that(xmlChildElementCount(testsuite), is_equal_to(1));
+
+    xmlNodePtr testcase = xmlFirstElementChild(testsuite);
+    assert_that(testcase->name, is_equal_to_string("testcase"));
+    assert_that(xmlChildElementCount(testcase), is_equal_to(1));
+    assert_that(hasAttribute(testcase, XMLSTRING("time")), is_true);
+
+    xmlNodePtr skipped = xmlFirstElementChild(testcase);
+    assert_that(skipped->name, is_equal_to_string("skipped"));
+    assert_that(xmlChildElementCount(skipped), is_equal_to(0));
+}
+
+
+Ensure(LibXmlReporter, will_report_non_finishing_test) {
+    const int line = 666;
+
+    reporter->start_suite(reporter, "suite_name", 1);
+    reporter->start_test(reporter, "test_name");
+    send_reporter_exception_notification(reporter);
+    reporter->finish_test(reporter, "filename", line, "message");
+    reporter->finish_suite(reporter, "filename", line);
+
+    xmlDocPtr doc = xmlParseDoc(output);
+    assert_that(doc, is_not_null);
+
+    xmlNodePtr testsuite = xmlDocGetRootElement(doc);
+    assert_that(xmlChildElementCount(testsuite), is_equal_to(1));
+
+    xmlNodePtr testcase = xmlFirstElementChild(testsuite);
+    assert_that(testcase->name, is_equal_to_string("testcase"));
+    assert_that(xmlChildElementCount(testcase), is_equal_to(1));
+    assert_that(hasAttribute(testcase, XMLSTRING("time")), is_true);
+
+    xmlNodePtr error = xmlFirstElementChild(testcase);
+    assert_that(error->name, is_equal_to_string("error"));
+    assert_that(error, xmlnode_has_attribute_equal_to("type", "Fatal"));
+    assert_that(error, xmlnode_has_attribute_equal_to("message", "message"));
+}
+
+Ensure(LibXmlReporter, will_report_time_correctly_for_non_finishing_test) {
+    const int line = 666;
+
+    reporter->start_suite(reporter, "suite_name", 1);
+    reporter->start_test(reporter, "test_name");
+    send_reporter_exception_notification(reporter);
+    reporter->finish_test(reporter, "filename", line, "message");
+    reporter->finish_suite(reporter, "filename", line);
+
+    assert_that(output, contains_string("name=\"test_name\""));
+    assert_that(output, contains_string(" time=\""));
+}
+
+TestSuite *libxml_reporter_tests(void) {
+    TestSuite *suite = create_test_suite();
+    set_setup(suite, setup_xml_reporter_tests);
+
+    add_test_with_context(suite, LibXmlReporter, will_report_beginning_of_suite);
+    add_test_with_context(suite, LibXmlReporter, will_report_beginning_and_successful_finishing_of_passing_test);
+    add_test_with_context(suite, LibXmlReporter, will_report_a_failing_test);
+    add_test_with_context(suite, LibXmlReporter, will_report_a_failing_test_only_once);
+    add_test_with_context(suite, LibXmlReporter, will_mark_ignored_test_as_skipped);
+    add_test_with_context(suite, LibXmlReporter, will_report_non_finishing_test);
+    add_test_with_context(suite, LibXmlReporter, will_report_time_correctly_for_non_finishing_test);
+
+    set_teardown(suite, teardown_xml_reporter_tests);
+    return suite;
+}

--- a/tests/libxml_reporter_tests.cpp
+++ b/tests/libxml_reporter_tests.cpp
@@ -1,0 +1,12 @@
+/*
+  This file used to be a link to the corresponding .c file because we
+  want to compile the same tests for C and C++. But since some systems
+  don't handle symbolic links the same way as *ix systems we get
+  inconsistencies (looking at you Cygwin) or plain out wrong (looking
+  at you MSYS2, copying ?!?!?) behaviour.
+
+  So we will simply include the complete .c source instead...
+ */
+
+#include "libxml_reporter_tests.c"
+

--- a/tests/normalize_libxml_output_tests.sed
+++ b/tests/normalize_libxml_output_tests.sed
@@ -1,0 +1,6 @@
+# 'time="?.?????"' => time="0.00000"
+s/time=".+"/time="0.00000"/g
+s/line=".+"/line="0"/g
+# filenames, suites, libraries and "classnames" starting with "lib" or "cyg"
+s/"lib/"/g
+s/"cyg/"/g

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -21,7 +21,7 @@ if (NM_FOUND)
    cmake_define_relative_file_paths("${RUNNER_SRCS}")
 
    add_executable(cgreen-runner ${RUNNER_SRCS})
-   target_link_libraries(cgreen-runner ${CGREEN_LIBRARY} ${CMAKE_DL_LIBS})
+   target_link_libraries(cgreen-runner ${CGREEN_LIBRARY} $<$<BOOL:${CGREEN_WITH_LIBXML2}>:${LIBXML2_LIBRARIES}> ${CMAKE_DL_LIBS})
 
    install(TARGETS cgreen-runner
      LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -96,6 +96,11 @@ if (NM_FOUND)
    macro_add_test(NAME cgreen_runner_with_xml_reporter
      COMMAND cgreen-runner --xml TEST --suite cgreen_runner_tests $<TARGET_FILE_DIR:cgreen_runner_tests>/$<TARGET_FILE_NAME:cgreen_runner_tests>)
 
+   if (CGREEN_WITH_LIBXML2)
+      macro_add_test(NAME cgreen_runner_with_libxml2_reporter
+         COMMAND cgreen-runner --libxml2 TEST --suite cgreen_runner_tests $<TARGET_FILE_DIR:cgreen_runner_tests>/$<TARGET_FILE_NAME:cgreen_runner_tests>)
+   endif (CGREEN_WITH_LIBXML2)
+
    macro_add_test(NAME cgreen_runner_multiple_libraries
      COMMAND cgreen-runner ${CGREEN_RUNNER_TESTS_LIBRARY} ${CGREEN_RUNNER_TESTS_LIBRARY} ${CGREEN_RUNNER_TESTS_LIBRARY})
 

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -93,8 +93,10 @@ if (NM_FOUND)
    macro_add_test(NAME cgreen_runner_wildcarded_tests_in_wildcarded_context
      COMMAND cgreen-runner $<TARGET_FILE_DIR:cgreen_runner_tests>/$<TARGET_FILE_NAME:cgreen_runner_tests> *:*)
 
-   macro_add_test(NAME cgreen_runner_with_xml_reporter
-     COMMAND cgreen-runner --xml TEST --suite cgreen_runner_tests $<TARGET_FILE_DIR:cgreen_runner_tests>/$<TARGET_FILE_NAME:cgreen_runner_tests>)
+   if (CGREEN_WITH_XML)
+     macro_add_test(NAME cgreen_runner_with_xml_reporter
+       COMMAND cgreen-runner --xml TEST --suite cgreen_runner_tests $<TARGET_FILE_DIR:cgreen_runner_tests>/$<TARGET_FILE_NAME:cgreen_runner_tests>)
+   endif (CGREEN_WITH_XML)
 
    if (CGREEN_WITH_LIBXML2)
       macro_add_test(NAME cgreen_runner_with_libxml2_reporter

--- a/tools/cgreen-runner.c
+++ b/tools/cgreen-runner.c
@@ -34,10 +34,10 @@ static void usage(const char *program_name) {
     printf("cgreen-runner for Cgreen unittest and mocking framework v%s\n\n", VERSION);
     printf("Usage:\n    %s [--suite <name>] [--verbose] [--quiet] [--no-run] "
 #if HAVE_XML_REPORTER
-           "--xml <prefix>"
+           "[--xml <prefix>] "
 #endif
 #if HAVE_LIBXML2_REPORTER
-           "--libxml2 <prefix>"
+           "[--libxml2 <prefix>] "
 #endif
            "[--help] (<library> [<test>])+\n\n", program_name);
     printf("Discover and run all or named cgreen test(s) from one or multiple\n");

--- a/tools/cgreen_libxml_output_diff
+++ b/tools/cgreen_libxml_output_diff
@@ -1,0 +1,118 @@
+#!/bin/bash
+#
+# Will run the cgreen-runner in directory ../tools
+# on library with name $1 (e.g. 'lib${name}.so')
+# generating XML output that will be compared to
+# sources are in $2 for...
+# ...expected output file name in $3
+# ...and commands to normalize output (in the file normalize_{name}.sed)
+#
+# Determine OS
+unameo=`uname -o 1>/dev/null 2>/dev/null; echo $?`
+if [ $unameo -eq 0 ]; then
+    OS=`uname -o`
+else
+    OS=`uname -s`
+fi
+
+# Set up library prefix and extension
+case "$OS" in
+Darwin)
+    prefix=lib
+    extension=dylib
+    ;;
+GNU/Linux|FreeBSD)
+    prefix=lib
+    extension=so
+    ;;
+Cygwin)
+    prefix=cyg
+    extension=dll
+    ;;
+Msys)
+    prefix=lib
+    extension=dll
+    ;;
+*)
+    echo "ERROR: $0 can't handle OS=$OS"
+    exit 2
+    ;;
+esac
+
+# Handle arguments
+if [ $# -ne 3 ]; then
+    echo "ERROR: $0 requires exactly 3 arguments"
+    exit 2
+fi
+
+# TODO: don't shift
+name=$1; shift 1
+
+sourcedir=$1 ; shift 1
+sourcedir=$(perl -e 'use Cwd "abs_path"; print abs_path(@ARGV[0])' -- "$sourcedir")
+if [ $(uname -n) = thoni64 ]; then
+    # On my Cygwin machine I have linked /home to c:/Users so absolute paths don't match
+    # what runner prints, so try to replace that (don't know how to generalize this...)
+    sourcedir=`echo $sourcedir | sed -e s#/cygdrive/c/Users#/home#`
+fi
+
+# TODO: don't shift
+expected=$1 ; shift 1
+
+commandfile="${sourcedir}/normalize_${name}.sed"
+
+# Do it!
+if [ -z "$CGREEN_PER_TEST_TIMEOUT" ]; then
+    printf "Comparing output of ${name} to expected: "
+else
+    printf "Comparing output of ${name} to expected with CGREEN_PER_TEST_TIMEOUT=$CGREEN_PER_TEST_TIMEOUT: "
+fi
+
+# Run runner on library store output and error
+../tools/cgreen-runner -X L "${prefix}${name}.${extension}" > "${name}.output" 2> "${name}.error"
+cat "${name}.error" >> "${name}.output"
+cat L-*${name}.xml L-*${name}-default.xml >> "${name}.output"
+
+tempfile=`mktemp`
+
+# sed commands to normalize...
+# - line numbers in error messages
+echo "s/:[0-9]+:/:/g" > $tempfile
+
+# - timing info
+echo "s/in [0-9]+ms\./in 0ms\./g" >> $tempfile
+
+# - library prefix
+# TODO: should use prefix, shouldn't it?
+echo s/\".*${name}\"/\"${name}\"/g >> $tempfile
+
+# - source path, ensure parenthesis are not interpreted by sed -E
+#                but allow any characters before sourcedir in the string
+echo s%\".*${sourcedir//[\(\)]/.}/%\"%g >> $tempfile
+
+# Do normalization using the commands in the tempfile and the specified commandfile
+sed -E -f "${tempfile}" -f "${commandfile}" "${name}.output"  > "${name}.output.normalized"
+
+# Check for color capability
+if test -t 1; then
+    ncolors=$(tput colors)
+
+    if test -n "$ncolors" && test $ncolors -ge 8; then
+        green="$(tput setaf 2)"
+        normal="$(tput sgr0)"
+     fi
+fi
+
+# Compare normalized output to expected
+cmp -s "${name}.output.normalized" "${sourcedir}/${expected}"
+
+# If not the same, show diff
+rc=$?
+if [ $rc -ne 0 ]
+then
+    echo
+    diff -c "${name}.output.normalized" "${sourcedir}/${expected}"
+else
+    echo ${green}Ok${normal}
+fi
+exit $rc


### PR DESCRIPTION
Selected by -X/--libxml for cgreen-runner, the report formatter uses libxml2 to construct an XML with report data. The libxml2 provides a complete and well-supported formatting of XML and UTF-8, and is better compatible with existing analyzing software, at the expense of build and run-time dependency on the libxml2 library.