### PR TITLE
Fix code coverage info generation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,7 +36,7 @@ script:
 after_success:
   - if [ "$CC" = "gcc" ];
     then
-      lcov -d tests -d src -d tools -d tools/tests -base-directory .. -c -o coverage.info;
+      lcov -d tests -d src -d tools -base-directory .. -c -o coverage.info;
       lcov --remove coverage.info '/usr/*' -o coverage.info;
       cd ..;
       coveralls-lcov build/coverage.info;


### PR DESCRIPTION
It seems to have been broken since moving the contents of tools/tests up to the "tools" directory.