### PR TITLE
Fix compilation on Windows because of the platform lacking unistd.h

### DIFF
--- a/include/cgreen/internal/cgreen_time.h
+++ b/include/cgreen/internal/cgreen_time.h
@@ -2,7 +2,6 @@
 #define CGREEN_TIME_HEADER
 
 #include <stdint.h>
-#include <unistd.h>
 
 #ifdef __cplusplus
 namespace cgreen {


### PR DESCRIPTION
Fortunately, the file `include/cgreen/internal/cgreen_time.h`, where the compilation fails, does not need it, so the `#include` can be simply removed.