### PR TITLE
Fix hyper link format error in cgreen-runner

### DIFF
--- a/doc/man/man1/cgreen-runner.1
+++ b/doc/man/man1/cgreen-runner.1
@@ -84,6 +84,6 @@ is in the
 .B Cgreen
 manual available at
 .UR https://github.com/cgreen-devs/cgreen
-GitHub.
-
+GitHub
+.UE .
 


### PR DESCRIPTION
This PR fixes an issue that I got during packaging 1.6.2 to Debian. 

I got a warning from lintian[1]:
groff-message error: automatically ending diversion 'an*link-text-div' on exit [usr/share/man/man1/cgreen-runner.1.gz:1]

I checked the man page format[2]. ".UR" and ".UE" are supposed to be a pair. ".UE" is missing for the github link.

[1] https://gavinlai-guest.pages.debian.net/-/cgreen/-/jobs/4560875/artifacts/debian/output/lintian.html
[2] https://man7.org/linux/man-pages/man7/groff_man_style.7.html

