### PR TITLE
Fix some functions when using cgreen with its namespace in C++.

### DIFF
--- a/include/cgreen/constraint_syntax_helpers.h
+++ b/include/cgreen/constraint_syntax_helpers.h
@@ -15,6 +15,45 @@
  * representation of the expected value and this is the only
  * reasonable way to do it.
  */
+#ifdef __cplusplus
+#define is_equal_to(value) cgreen::create_equal_to_value_constraint((intptr_t)value, #value)
+#define is_equal_to_hex(value) cgreen::create_equal_to_hexvalue_constraint((intptr_t)value, #value)
+#define is_not_equal_to(value) cgreen::create_not_equal_to_value_constraint((intptr_t)value, #value)
+#define is_non_null is_not_null
+#define is_not_null cgreen::create_not_null_constraint()
+#define is_null cgreen::create_is_null_constraint()
+#define is_false cgreen::create_is_false_constraint()
+#define is_true cgreen::create_is_true_constraint()
+
+#define is_greater_than(value) cgreen::create_greater_than_value_constraint((intptr_t)value, #value)
+#define is_less_than(value) cgreen::create_less_than_value_constraint((intptr_t)value, #value)
+
+#define is_equal_to_contents_of(pointer, size_of_contents) cgreen::create_equal_to_contents_constraint((void *)pointer, size_of_contents, #pointer)
+#define is_not_equal_to_contents_of(pointer, size_of_contents) cgreen::create_not_equal_to_contents_constraint((void *)pointer, size_of_contents, #pointer)
+
+#define is_equal_to_string(value) cgreen::create_equal_to_string_constraint(value, #value)
+#define is_not_equal_to_string(value) cgreen::create_not_equal_to_string_constraint(value, #value)
+#define contains_string(value) cgreen::create_contains_string_constraint(value, #value)
+#define does_not_contain_string(value) cgreen::create_does_not_contain_string_constraint(value, #value)
+#define begins_with_string(value) cgreen::create_begins_with_string_constraint(value, #value)
+#define does_not_begin_with_string(value) cgreen::create_does_not_begin_with_string_constraint(value, #value)
+#define ends_with_string(value) cgreen::create_ends_with_string_constraint(value, #value)
+#define does_not_end_with_string(value) cgreen::create_does_not_end_with_string_constraint(value, #value)
+
+#define is_equal_to_double(value) cgreen::create_equal_to_double_constraint(value, #value)
+#define is_not_equal_to_double(value) cgreen::create_not_equal_to_double_constraint(value, #value)
+
+#define is_less_than_double(value) cgreen::create_less_than_double_constraint(value, #value)
+#define is_greater_than_double(value) cgreen::create_greater_than_double_constraint(value, #value)
+
+
+#define with_side_effect(callback, data) cgreen::create_with_side_effect_constraint(callback, data)
+#define will_return(value) cgreen::create_return_value_constraint((intptr_t)value)
+#define will_return_by_value(value, size) cgreen::create_return_by_value_constraint((intptr_t)&value, size)
+#define will_return_double(value) cgreen::create_return_double_value_constraint(value)
+#define will_set_contents_of_parameter(parameter_name, pointer_to_value, size) cgreen::create_set_parameter_value_constraint(#parameter_name, (intptr_t)pointer_to_value, (size_t)size)
+#define will_capture_parameter(parameter_name, local_variable) cgreen::create_capture_parameter_constraint(#parameter_name, &local_variable, sizeof(local_variable))
+#else
 #define is_equal_to(value) create_equal_to_value_constraint((intptr_t)value, #value)
 #define is_equal_to_hex(value) create_equal_to_hexvalue_constraint((intptr_t)value, #value)
 #define is_not_equal_to(value) create_not_equal_to_value_constraint((intptr_t)value, #value)
@@ -52,5 +91,6 @@
 #define will_return_double(value) create_return_double_value_constraint(value)
 #define will_set_contents_of_parameter(parameter_name, pointer_to_value, size) create_set_parameter_value_constraint(#parameter_name, (intptr_t)pointer_to_value, (size_t)size)
 #define will_capture_parameter(parameter_name, local_variable) create_capture_parameter_constraint(#parameter_name, &local_variable, sizeof(local_variable))
+#endif
 
 #endif

--- a/include/cgreen/internal/c_assertions.h
+++ b/include/cgreen/internal/c_assertions.h
@@ -12,13 +12,15 @@
 #endif
 
 #ifdef __cplusplus
-extern "C" {
+namespace cgreen {
+    extern "C" {
 #endif
 
 void assert_core_(const char *file, int line, const char *actual_string, intptr_t actual, Constraint *constraint);
 void assert_that_double_(const char *file, int line, const char *expression, double actual, Constraint* constraint);
 
 #ifdef __cplusplus
+    }
 }
 #endif
 


### PR DESCRIPTION
Hello,

Using cgreen for C++ without including `using namespace cgreen` in the code results in compilation errors when one attempts to use `cgreen::assert_that()`.

I just prefixed some things with `cgreen::` and added `namespace cgreen {` where appropriate.

The changes from this patch fixed the parts of cgreen I utilized but I haven't been able to test everything in cgreen.

Ideally I wanted to add the cgreen namespace to `TestSuite` in `include/cgreen/internal/suite_internal.h` as well but since that has `namespace cgreen {` later, I take it there was a good reason not to add TestSuite to the cgreen namespace.

Those who are applying `using namespace cgreen` to get around the compilation error should see no difference.