### PR TITLE
Allow Multiple Describes in a single test.c file

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.10)
+cmake_minimum_required(VERSION 3.3)
 
 project(cgreen)
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -46,6 +46,7 @@ set(c_tests_library_SRCS
   messaging_tests.c
   mocks_tests.c
   mocks_struct_tests.c
+  multiple_suite_tests.c
   parameters_tests.c
   reflective_runner_no_teardown_tests.c
   reflective_tests.c

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -27,6 +27,7 @@ TEST_SOURCES = \
 	message_formatting_tests.c \
 	messaging_tests.c \
 	mocks_tests.c \
+	multiple_suite_tests.c \
 	parameters_tests.c \
 	reflective_runner_no_teardown_tests.c \
 	reflective_tests.c \

--- a/tests/all_c_tests.c
+++ b/tests/all_c_tests.c
@@ -28,6 +28,8 @@ TestSuite *unit_tests(void);
 TestSuite *vector_tests(void);
 TestSuite *xml_reporter_tests(void);
 TestSuite *libxml_reporter_tests(void);
+TestSuite *test_suite_a(void);
+TestSuite *test_suite_b(void);
 
 int main(int argc, char **argv) {
     int suite_result;
@@ -46,6 +48,8 @@ int main(int argc, char **argv) {
     add_suite(suite, message_formatting_tests());
     add_suite(suite, messaging_tests());
     add_suite(suite, mock_tests());
+    add_suite(suite, test_suite_a());
+    add_suite(suite, test_suite_b());
     add_suite(suite, parameter_tests());
     add_suite(suite, reflective_no_teardown_tests());
     add_suite(suite, reflective_tests());

--- a/tests/multiple_suite_tests.c
+++ b/tests/multiple_suite_tests.c
@@ -1,0 +1,45 @@
+#include <cgreen/cgreen.h>
+
+#ifdef __cplusplus
+using namespace cgreen;
+#endif
+
+// This funciton exemplifies infrastructure common between multiple suits 
+int common_func_btw_SUTs()
+{
+    return 0;
+}
+
+// Suite A and its unit test
+Describe(SuiteA);
+BeforeEach(SuiteA) {}
+AfterEach(SuiteA) {}
+
+Ensure(SuiteA, ut_a) {
+    int num = common_func_btw_SUTs();
+    assert_that(num, is_equal_to(0));
+}
+
+// Suite B and its unit test
+Describe(SuiteB);
+BeforeEach(SuiteB) {}
+AfterEach(SuiteB) {}
+
+Ensure(SuiteB, ut_b) {
+    int num = common_func_btw_SUTs();
+    assert_that(num, is_equal_to(0));
+}
+
+TestSuite *test_suite_a(void) {
+    TestSuite *suite = create_test_suite();
+    add_test_with_context(suite, SuiteA, ut_a);
+    run_test_suite(suite, create_text_reporter());
+    return suite;
+}
+
+TestSuite *test_suite_b(void) {
+    TestSuite *suite = create_test_suite();
+    add_test_with_context(suite, SuiteB, ut_b);
+    run_test_suite(suite, create_text_reporter());
+    return suite;
+}

--- a/tests/multiple_suite_tests.c
+++ b/tests/multiple_suite_tests.c
@@ -5,8 +5,7 @@ using namespace cgreen;
 #endif
 
 // This funciton exemplifies infrastructure common between multiple suits 
-int common_func_btw_SUTs()
-{
+static int common_func_btw_SUTs(void) {
     return 0;
 }
 

--- a/tests/multiple_suite_tests.cpp
+++ b/tests/multiple_suite_tests.cpp
@@ -1,0 +1,11 @@
+/*
+  This file used to be a link to the corresponding .c file because we
+  want to compile the same tests for C and C++. But since some systems
+  don't handle symbolic links the same way as *ix systems we get
+  inconsistencies (looking at you Cygwin) or plain out wrong (looking
+  at you MSYS2, copying ?!?!?) behaviour.
+
+  So we will simply include the complete .c source instead...
+ */
+
+#include "multiple_suite_tests.c"


### PR DESCRIPTION
This pull request is taking the changes from [PR#329](https://github.com/cgreen-devs/cgreen/pull/329) opened by [smazhar-cetitec](https://github.com/cgreen-devs/cgreen/issues?q=is%3Apr+is%3Aopen+author%3Asmazhar-cetitec). I have taken the changes from his fork and made some changes to the tests. 
This PR includes the following changes

- Multiple describes
- Test to validate multiple SUT and Describe in a single test.c file
- Downgrading to `cmake_minimum_required(VERSION 3.3)` 

Locally this is tested on a ubuntu 18.04 container with gcc v9.4 and cmake v3.16