### PR TITLE
Increase macro hygiene in constraint helper macros

### DIFF
--- a/include/cgreen/constraint_syntax_helpers.h
+++ b/include/cgreen/constraint_syntax_helpers.h
@@ -15,20 +15,20 @@
  * representation of the expected value and this is the only
  * reasonable way to do it.
  */
-#define is_equal_to(value) create_equal_to_value_constraint((intptr_t)value, #value)
-#define is_equal_to_hex(value) create_equal_to_hexvalue_constraint((intptr_t)value, #value)
-#define is_not_equal_to(value) create_not_equal_to_value_constraint((intptr_t)value, #value)
+#define is_equal_to(value) create_equal_to_value_constraint((intptr_t)(value), #value)
+#define is_equal_to_hex(value) create_equal_to_hexvalue_constraint((intptr_t)(value), #value)
+#define is_not_equal_to(value) create_not_equal_to_value_constraint((intptr_t)(value), #value)
 #define is_non_null is_not_null
 #define is_not_null create_not_null_constraint()
 #define is_null create_is_null_constraint()
 #define is_false create_is_false_constraint()
 #define is_true create_is_true_constraint()
 
-#define is_greater_than(value) create_greater_than_value_constraint((intptr_t)value, #value)
-#define is_less_than(value) create_less_than_value_constraint((intptr_t)value, #value)
+#define is_greater_than(value) create_greater_than_value_constraint((intptr_t)(value), #value)
+#define is_less_than(value) create_less_than_value_constraint((intptr_t)(value), #value)
 
-#define is_equal_to_contents_of(pointer, size_of_contents) create_equal_to_contents_constraint((void *)pointer, size_of_contents, #pointer)
-#define is_not_equal_to_contents_of(pointer, size_of_contents) create_not_equal_to_contents_constraint((void *)pointer, size_of_contents, #pointer)
+#define is_equal_to_contents_of(pointer, size_of_contents) create_equal_to_contents_constraint((void *)(pointer), size_of_contents, #pointer)
+#define is_not_equal_to_contents_of(pointer, size_of_contents) create_not_equal_to_contents_constraint((void *)(pointer), size_of_contents, #pointer)
 
 #define is_equal_to_string(value) create_equal_to_string_constraint(value, #value)
 #define is_not_equal_to_string(value) create_not_equal_to_string_constraint(value, #value)
@@ -47,11 +47,11 @@
 
 
 #define with_side_effect(callback, data) create_with_side_effect_constraint(callback, data)
-#define will_return(value) create_return_value_constraint((intptr_t)value)
-#define will_return_by_value(value, size) create_return_by_value_constraint((intptr_t)&value, size)
+#define will_return(value) create_return_value_constraint((intptr_t)(value))
+#define will_return_by_value(value, size) create_return_by_value_constraint((intptr_t)&(value), size)
 #define will_return_double(value) create_return_double_value_constraint(value)
-#define will_set_contents_of_parameter(parameter_name, pointer_to_value, size) create_set_parameter_value_constraint(#parameter_name, (intptr_t)pointer_to_value, (size_t)size)
-#define will_set_contents_of_output_parameter(parameter_name, pointer_to_value, size) create_set_parameter_value_constraint(#parameter_name, (intptr_t)pointer_to_value, (size_t)size)
-#define will_capture_parameter(parameter_name, local_variable) create_capture_parameter_constraint(#parameter_name, &local_variable, sizeof(local_variable))
+#define will_set_contents_of_parameter(parameter_name, pointer_to_value, size) create_set_parameter_value_constraint(#parameter_name, (intptr_t)(pointer_to_value), (size_t)(size))
+#define will_set_contents_of_output_parameter(parameter_name, pointer_to_value, size) create_set_parameter_value_constraint(#parameter_name, (intptr_t)(pointer_to_value), (size_t)(size))
+#define will_capture_parameter(parameter_name, local_variable) create_capture_parameter_constraint(#parameter_name, &(local_variable), sizeof(local_variable))
 
 #endif

--- a/tests/assertion_tests.c
+++ b/tests/assertion_tests.c
@@ -149,6 +149,20 @@ Ensure(different_pointers_with_same_contents_should_assert_equal) {
     );
 }
 
+Ensure(support_for_pointer_arithmetic) {
+    
+    int data[2][4] = {{0,1,2,3},{7,8,9,10}};
+    int same_data[2][4] = {{0,1,2,3}, {7,8,9,10}};
+    size_t data_sz = sizeof(data)/sizeof(data[0]);
+    printf("%s,%d: data_sz = %ld\n", __FILE__, __LINE__, data_sz);
+    for (size_t i = 0; i < data_sz; i++)
+    {
+        assert_that(data + i,
+            is_equal_to_contents_of(same_data + i, sizeof(same_data[i]))
+        );
+    }
+}
+
 Ensure(one_should_assert_float_equal_to_one) {
     float x = 1;
     float y = 1;
@@ -354,5 +368,6 @@ TestSuite *assertion_tests(void) {
     add_test(suite, inspecting_contents_of_with_zero_size_produces_nice_error_message);
     add_test(suite, fail_reports_message);
     add_test(suite, return_value_constraints_are_not_allowed);
+    add_test(suite, support_for_pointer_arithmetic);
     return suite;
 }


### PR DESCRIPTION
Increase macro hygiene in constraint helper macros to make pointer arithmetic safe
Unit test added to validate this