### PR TITLE
[fix] Zero-initialize CgreenValue in make_cgreen_integer_value

### DIFF
--- a/src/cgreen_value.c
+++ b/src/cgreen_value.c
@@ -18,7 +18,10 @@ CgreenValue *create_cgreen_value(CgreenValue value) {
 }
 
 CgreenValue make_cgreen_integer_value(intptr_t integer) {
-    CgreenValue value = {CGREEN_INTEGER, {0}, sizeof(intptr_t)};
+    CgreenValue value;
+    value.type = CGREEN_INTEGER;
+    value.value_size = sizeof(intptr_t);
+    memset(&value.value, 0, sizeof(value.value));
     value.value.integer_value = integer;
     return value;
 }


### PR DESCRIPTION
Hi,

Recently, Debian has moved to a new version. Some relevant packages have updates. I am working on keeping cgreen in good shape. One of the issues I noticed is that in the current Debian sid, the i386 arch cannot pass the tests. However, the amd64 architecture can pass the test.


Reference: https://salsa.debian.org/gavinlai-guest/cgreen/-/jobs/8188081
```
11/30 Testing: assertion_messages
11/30 Test: assertion_messages
Command: "/builds/gavinlai-guest/cgreen/debian/output/source_dir/tools/cgreen_runner_output_diff" "assertion_messages_tests" "/builds/gavinlai-guest/cgreen/debian/output/source_dir/tests" "assertion_messages_tests.expected"
Directory: /builds/gavinlai-guest/cgreen/debian/output/source_dir/build/tests
"assertion_messages" start time: Sep 05 06:17 UTC
Output:
----------------------------------------------------------
Comparing output of assertion_messages_tests to expected: 
*** assertion_messages_tests.output.normalized	Fri Sep  5 06:17:36 2025
--- /builds/gavinlai-guest/cgreen/debian/output/source_dir/tests/assertion_messages_tests.expected	Fri Sep  5 06:11:37 2025
***************
*** 29,40 ****
  		should only be used with 'assert_that_double()' to ensure proper comparison.
  
  assertion_messages_tests.c:000: Failure: AssertionMessage -> for_using_double_constraints_with_assert_that 
- 	Expected [0] to [be less than double] [3.1415926]
- 
- assertion_messages_tests.c:000: Failure: AssertionMessage -> for_using_double_constraints_with_assert_that 
  	Constraints of double type, such as [be greater than double],
  		should only be used with 'assert_that_double()' to ensure proper comparison.
  
  assertion_messages_tests.c:000: Failure: AssertionMessage -> for_using_non_double_constraints_with_assert_that_double 
  	Only constraints of double type should be used with 'assert_that_double()'.
  		Other types of constraints, such as [equal], will probably fail comparison.
--- 29,40 ----
  		should only be used with 'assert_that_double()' to ensure proper comparison.
  
  assertion_messages_tests.c:000: Failure: AssertionMessage -> for_using_double_constraints_with_assert_that 
  	Constraints of double type, such as [be greater than double],
  		should only be used with 'assert_that_double()' to ensure proper comparison.
  
+ assertion_messages_tests.c:000: Failure: AssertionMessage -> for_using_double_constraints_with_assert_that 
+ 	Expected [7] to [be greater than double] [3.1415926]
+ 
  assertion_messages_tests.c:000: Failure: AssertionMessage -> for_using_non_double_constraints_with_assert_that_double 
  	Only constraints of double type should be used with 'assert_that_double()'.
  		Other types of constraints, such as [equal], will probably fail comparison.
***************
*** 42,48 ****
  assertion_messages_tests.c:000: Failure: AssertionMessage -> for_using_non_double_constraints_with_assert_that_double 
  	Expected [3] to [equal] [3] within [8] significant figures
  		actual value:			[3.000000]
! 		expected value:			[307266871732049025231842139123423286263684571059823714574064072797806460840816741950232968526420844825957321670656.000000]
  
  assertion_messages_tests.c:000: Failure: AssertionMessage -> return_value_constraints_are_not_allowed 
  	Got constraint of type [return value],
--- 42,48 ----
  assertion_messages_tests.c:000: Failure: AssertionMessage -> for_using_non_double_constraints_with_assert_that_double 
  	Expected [3] to [equal] [3] within [8] significant figures
  		actual value:			[3.000000]
! 		expected value:			[0.000000]
  
  assertion_messages_tests.c:000: Failure: AssertionMessage -> return_value_constraints_are_not_allowed 
  	Got constraint of type [return value],
<end of output>
Test time =   0.04 sec
----------------------------------------------------------
Test Failed.
"assertion_messages" end time: Sep 05 06:17 UTC
"assertion_messages" time elapsed: 00:00:00
```

After some investigations, I believe the memory region of value.value is not completely initialized. The current approach is to clean the memory region explicitly. With this patch, i386 can pass the test. (Reference: https://salsa.debian.org/gavinlai-guest/cgreen/-/jobs/8241041).

Although the patch can pass the tests, there are two items worth discussing.  
(1) Other functions are initialized like this function. Other functions may also need changes.
(2) I agree that the original one-line initialization is elegant. If there are other suggestions, I am happy to modify the approach and retest it in the Debian sid environment.

